### PR TITLE
Wait for API server to be ready before continuing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,12 @@ resource "aws_eks_cluster" "control_plane" {
   }
 
   depends_on = [aws_cloudwatch_log_group.control_plane]
+
+  provisioner "local-exec" {
+    # wait for api to be avalible for use by the kubernetes provider before continuing
+    command     = "until curl --output /dev/null --insecure --silent ${self.endpoint}/healthz; do sleep 1; done"
+    working_dir = path.module
+  }
 }
 
 resource "aws_cloudwatch_log_group" "control_plane" {


### PR DESCRIPTION
Fixes errors like:

Unable to connect to the server: dial tcp i/o timeout