### PR TITLE
Change the default of endpoint_public_access to true

### DIFF
--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -38,9 +38,6 @@ module "cluster" {
 
   name = var.cluster_name
 
-  # So we can access the k8s API from CI/dev
-  endpoint_public_access = true
-
   vpc_config = {
     vpc_id = data.aws_vpc.network.id
     public_subnet_ids = {

--- a/examples/eks/main.tf
+++ b/examples/eks/main.tf
@@ -10,7 +10,4 @@ module "eks" {
   cluster_name       = var.cluster_name
   cidr_block         = var.cidr_block
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
-
-  # So we can access the k8s API from CI/dev
-  endpoint_public_access = true
 }

--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,7 @@ module "iam" {
 module "cluster" {
   source = "./modules/cluster"
 
-  name                   = var.cluster_name
-  endpoint_public_access = var.endpoint_public_access
+  name = var.cluster_name
 
   vpc_config = module.vpc.config
   iam_config = module.iam.config

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -9,7 +9,7 @@ variable "k8s_version" {
 variable "endpoint_public_access" {
   type        = bool
   description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled."
-  default     = false
+  default     = true
 }
 
 variable "cluster_log_types" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,12 +13,6 @@ variable "availability_zones" {
   description = "The availability zones to launch worker nodes in"
 }
 
-variable "endpoint_public_access" {
-  type        = bool
-  description = "Indicates whether or not the EKS public API server endpoint is enabled."
-  default     = false
-}
-
 variable "aws_auth_role_map" {
   default     = []
   description = "A list of mappings from aws role arns to kubernetes users, and their groups"


### PR DESCRIPTION
Fixes #55

This seems to be the more useful default for any users running
automation outside of AWS.