### PR TITLE
Fix the behaviour of min_size to match(ish) max_size

### DIFF
--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -14,6 +14,7 @@ locals {
   labels         = merge({ "node-role.kubernetes.io/${local.node_role}" = "true" }, var.labels)
   asg_subnets    = var.zone_awareness ? { for az, subnet in var.cluster_config.private_subnet_ids : az => [subnet] } : { "multi-zone" = values(var.cluster_config.private_subnet_ids) }
   max_size       = floor(var.max_size / length(local.asg_subnets))
+  min_size       = ceil(var.min_size / length(local.asg_subnets))
 }
 
 data "aws_ssm_parameter" "image_id" {
@@ -94,7 +95,7 @@ resource "aws_autoscaling_group" "nodes" {
   for_each = local.asg_subnets
 
   name                = "${local.name_prefix}-${each.key}"
-  min_size            = var.min_size
+  min_size            = local.min_size
   max_size            = local.max_size
   vpc_zone_identifier = each.value
 

--- a/modules/asg_node_group/variables.tf
+++ b/modules/asg_node_group/variables.tf
@@ -40,13 +40,13 @@ variable "docker_volume_size" {
 variable "max_size" {
   type        = number
   default     = 12
-  description = "The maximum number of instances that will be launched by this group"
+  description = "The maximum number of instances that will be launched by this group, if not a multiple of the number of AZs in the group, may be rounded down"
 }
 
 variable "min_size" {
   type        = number
   default     = 0
-  description = "The minimum number of instances in each ASG, should only be needed if not using cluster autoscaler or bootstapping"
+  description = "The minimum number of instances that will be launched by this group, if not a multiple of the number of AZs in the group, may be rounded up"
 }
 
 variable "instance_size" {


### PR DESCRIPTION
Currently min_size is the minimum size for each asg. This is confusing because max_size refers to the total number of nodes across all asg's managed by the asg_node_group. This change makes the behaviour more consistent.