### PR TITLE
Adds an option to disable evelope encryption

### DIFF
--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -100,6 +100,12 @@ variable "aws_auth_user_map" {
   description = "A list of mappings from aws user arns to kubernetes users, and their groups"
 }
 
+variable "envelope_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = "Should Cluster Envelope Encryption be enabled, if changed after provisioning - forces the cluster to be recreated"
+}
+
 variable "kms_cmk_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
This is needed as legacy clusters were created before it existed, and
this setting cannot be changed on an existing cluster without
recreation.