### PR TITLE
Remove docker EBS volume

### DIFF
--- a/modules/asg_node_group/README.md
+++ b/modules/asg_node_group/README.md
@@ -8,7 +8,6 @@ This module provisions nodes for your cluster by managing AWS auto scaling group
 * Provisions an auto scaling group per availability zone, to support applications
   utilizing EBS volumes via PVC.
 * Prepares the auto scaling group(s) to be scaled by the cluster autoscaler.
-* Configures a separate EBS volume for use as the docker volume.
 * Uses the official AWS EKS optimised Amazon Linux AMI
 
 ## Usage
@@ -106,7 +105,7 @@ module "nodes" {
 
 ### Volume size
 
-You can configure the root and docker volume size (they default to 20 GiB).
+You can configure the root volume size (it defaults to 40 GiB).
 
 e.g.
 
@@ -116,7 +115,6 @@ module "nodes" {
 
   cluster_config     = module.cluster.config
   root_volume_size   = 10
-  docker_volume_size = 50
 }
 
 ```

--- a/modules/asg_node_group/cloud_config.tpl
+++ b/modules/asg_node_group/cloud_config.tpl
@@ -1,14 +1,6 @@
 ## template: jinja
 #cloud-config
 fqdn: eks-node-${cluster_name}-{{ v1.instance_id }}
-fs_setup:
-# Create a filesystem on the attached EBS volume
-- device: ${docker_volume_device}
-  filesystem: ext4
-  label: docker-vol
-  partition: none
-mounts:
-- [/dev/disk/by-label/docker-vol, /var/lib/docker, ext4, "defaults,noatime", 0, 0]
 runcmd:
 - [aws, --region={{ v1.region }}, ec2, create-tags, --resources={{ v1.instance_id }}, "--tags=Key=Name,Value=eks-node-${cluster_name}-{{ v1.instance_id }}"]
 - [systemctl, restart, docker]

--- a/modules/asg_node_group/variables.tf
+++ b/modules/asg_node_group/variables.tf
@@ -18,26 +18,10 @@ variable "zone_awareness" {
   description = "Should the cluster autoscaler be aware of the AZ it is launching nodes into, if true then one ASG is created per AZ. If false a single AZ spanning all the zones will be created, applications making use of EBS volumes may not work as expected"
 }
 
-variable "root_volume_device" {
-  type    = string
-  default = "/dev/xvda"
-}
-
 variable "root_volume_size" {
   type        = number
-  default     = 20
+  default     = 40
   description = "Volume size for the root partition. Value in GiB."
-}
-
-variable "docker_volume_device" {
-  type    = string
-  default = "/dev/xvdf"
-}
-
-variable "docker_volume_size" {
-  type        = number
-  default     = 20
-  description = "Volume size for the docker volume. Value in GiB."
 }
 
 variable "max_size" {


### PR DESCRIPTION
As an alternative to #82 removing the extra EBS volume for
/var/lib/docker simplifies this setup and makes provisioning nodes simpler to
understand.

We can just rely on the root EBS volume, if more storage / performance
is required, the operator can just make the volume larger!