### PR TITLE
Fix empty tuple key error

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -178,8 +178,8 @@ module "storage_classes" {
 
 locals {
   create_key         = length(var.kms_cmk_arn) == 0 && var.envelope_encryption_enabled
-  kms_cmk_arn        = local.create_key ? aws_kms_key.cmk[0].arn : var.kms_cmk_arn
-  encryption_configs = var.envelope_encryption_enabled ? [local.kms_cmk_arn] : []
+  kms_cmk_arn        = local.create_key ? aws_kms_key.cmk.*.arn : [var.kms_cmk_arn]
+  encryption_configs = var.envelope_encryption_enabled ? local.kms_cmk_arn : []
 }
 
 resource "aws_kms_key" "cmk" {


### PR DESCRIPTION
Fixes error when `envelope_encryption_enabled = false`

```
Error: Invalid index

  on .terraform/modules/staging-cluster/terraform-aws-eks-1.14.1/modules/cluster/main.tf line 181, in locals:
 181:   kms_cmk_arn        = local.create_key ? aws_kms_key.cmk[0].arn : var.kms_cmk_arn
    |----------------
    | aws_kms_key.cmk is empty tuple

The given key does not identify an element in this collection value.
```