### PR TITLE
Don't specify text/jinja2 in cloudconfig parts

### DIFF
--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -48,14 +48,14 @@ data "template_cloudinit_config" "config" {
   base64_encode = true
 
   part {
-    content_type = "text/jinja2"
+    content_type = "text/plain"
     content      = data.template_file.cloud_config.rendered
   }
 
   dynamic "part" {
     for_each = var.cloud_config
     content {
-      content_type = "text/jinja2"
+      content_type = "text/plain"
       content      = part.value
       merge_type   = "list(append)+dict(recurse_list)+str()"
     }


### PR DESCRIPTION
In order to use jinja2 the file  needs to have the `## template: jinja`
comment anyway, without this cloud-config only uses the "basic" renderer
anyway!

https://github.com/canonical/cloud-init/blob/19.3/cloudinit/templater.py#L121

Fixes #102