### PR TITLE
Fix empty tuple error on terraform import

### DIFF
--- a/modules/cluster/cluster_autoscaler_iam.tf
+++ b/modules/cluster/cluster_autoscaler_iam.tf
@@ -1,6 +1,6 @@
 locals {
   cluster_autoscaler_iam_role_count = length(var.cluster_autoscaler_iam_role_arn) == 0 && var.cluster_autoscaler ? 1 : 0
-  cluster_autoscaler_iam_role_arn   = length(var.cluster_autoscaler_iam_role_arn) > 0 || ! var.cluster_autoscaler ? var.cluster_autoscaler_iam_role_arn : aws_iam_role.cluster_autoscaler[0].arn
+  cluster_autoscaler_iam_role_arn   = length(var.cluster_autoscaler_iam_role_arn) > 0 ? var.cluster_autoscaler_iam_role_arn : join("", aws_iam_role.cluster_autoscaler.*.arn)
 }
 
 data "aws_iam_policy_document" "cluster_autoscaler_assume_role_policy" {


### PR DESCRIPTION
If cluster autoscaler is disabled we can bump into  an error like:

```
Error: Invalid index
  on .terraform/modules/eks-cluster-monitoring/terraform-aws-eks-1.15.0-rc4/modules/cluster/cluster_autoscaler_iam.tf line 3, in locals:
   3:   cluster_autoscaler_iam_role_arn   = length(var.cluster_autoscaler_iam_role_arn) > 0 || ! var.cluster_autoscaler ? var.cluster_autoscaler_iam_role_arn : aws_iam_role.cluster_autoscaler[0].arn
    |----------------
    | aws_iam_role.cluster_autoscaler is empty tuple
The given key does not identify an element in this collection value.
```

This should workaround the issue :(