### PR TITLE
Update Amazon VPC CNI plugin to 1.6.1

### DIFF
--- a/modules/cluster/addons/aws-k8s-cni.yaml
+++ b/modules/cluster/addons/aws-k8s-cni.yaml
@@ -77,7 +77,20 @@ spec:
                     operator: In
                     values:
                       - amd64
-                  - key: eks.amazonaws.com/compute-type
+                  - key: "eks.amazonaws.com/compute-type"
+                    operator: NotIn
+                    values:
+                      - fargate
+              - matchExpressions:
+                  - key: "kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
+                  - key: "eks.amazonaws.com/compute-type"
                     operator: NotIn
                     values:
                       - fargate
@@ -86,15 +99,27 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.7
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.1
           imagePullPolicy: Always
           ports:
             - containerPort: 61678
               name: metrics
           name: aws-node
+          readinessProbe:
+            exec:
+              command: ["/app/grpc-health-probe", "-addr=:50051"]
+            initialDelaySeconds: 35
+          livenessProbe:
+            exec:
+              command: ["/app/grpc-health-probe", "-addr=:50051"]
+            initialDelaySeconds: 35
           env:
             - name: AWS_VPC_K8S_CNI_LOGLEVEL
               value: DEBUG
+            - name: AWS_VPC_K8S_CNI_VETHPREFIX
+              value: eni
+            - name: AWS_VPC_ENI_MTU
+              value: "9001"
             - name: MY_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
The manifest is updated with the following command:

```
curl -s https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6.1/config/v1.6/aws-k8s-cni.yaml -o modules/cluster/addons/aws-k8s-cni.yaml
```

1.6.1 is the version currently recommended in https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html.

Changelog: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/CHANGELOG.md#v161