### PR TITLE
Add IAM permissions_boundary variable for cluster_autoscaler IAM role

### DIFF
--- a/modules/cluster/cluster_autoscaler_iam.tf
+++ b/modules/cluster/cluster_autoscaler_iam.tf
@@ -22,9 +22,10 @@ data "aws_iam_policy_document" "cluster_autoscaler_assume_role_policy" {
 }
 
 resource "aws_iam_role" "cluster_autoscaler" {
-  count              = local.cluster_autoscaler_iam_role_count
-  name               = "EksClusterAutoscaler-${var.name}"
-  assume_role_policy = data.aws_iam_policy_document.cluster_autoscaler_assume_role_policy.json
+  count                = local.cluster_autoscaler_iam_role_count
+  name                 = "EksClusterAutoscaler-${var.name}"
+  assume_role_policy   = data.aws_iam_policy_document.cluster_autoscaler_assume_role_policy.json
+  permissions_boundary = var.iam_permissions_boundary
 }
 
 data "aws_iam_policy_document" "cluster_autoscaler_policy" {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -42,6 +42,12 @@ variable "iam_config" {
   description = "The IAM roles used by the cluster, If you use the included IAM module you can provide it's config output variable."
 }
 
+variable "iam_permissions_boundary" {
+  type        = string
+  default     = ""
+  description = "The ARN of the policy that is used to set the permissions boundary for the role."
+}
+
 variable "oidc_root_ca_thumbprints" {
   type        = list(string)
   default     = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]


### PR DESCRIPTION
## Background

I'd like to add an option to set up [IAM Permissions boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)

A permissions boundary is an advanced feature for using a managed policy to set the maximum permissions that an identity-based policy can grant to an IAM entity. An entity's permissions boundary allows it to perform only the actions that are allowed by both its identity-based policies and its permissions boundaries.


## Reference

* Terrafrom aws_iam_role: https://www.terraform.io/docs/providers/aws/d/iam_role.html