### PR TITLE
Add variables for critical-addons

### DIFF
--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -7,7 +7,6 @@ module "critical_addons_node_group" {
   key_name         = var.critical_addons_node_group_key_name
   min_size         = var.critical_addons_node_group_min_size
   max_size         = var.critical_addons_node_group_max_size
-  desired_capacity = var.critical_addons_node_group_desired_capacity
   instance_family  = var.critical_addons_node_group_instance_family
   instance_size    = var.critical_addons_node_group_instance_size
   security_groups  = var.critical_addons_node_group_security_groups

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -4,12 +4,12 @@ module "critical_addons_node_group" {
   name           = "critical-addons"
   cluster_config = local.config
 
-  key_name         = var.critical_addons_node_group_key_name
-  min_size         = var.critical_addons_node_group_min_size
-  max_size         = var.critical_addons_node_group_max_size
-  instance_family  = var.critical_addons_node_group_instance_family
-  instance_size    = var.critical_addons_node_group_instance_size
-  security_groups  = var.critical_addons_node_group_security_groups
+  key_name        = var.critical_addons_node_group_key_name
+  min_size        = var.critical_addons_node_group_min_size
+  max_size        = var.critical_addons_node_group_max_size
+  instance_family = var.critical_addons_node_group_instance_family
+  instance_size   = var.critical_addons_node_group_instance_size
+  security_groups = var.critical_addons_node_group_security_groups
 
   zone_awareness = false
   taints = {

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -3,8 +3,15 @@ module "critical_addons_node_group" {
 
   name           = "critical-addons"
   cluster_config = local.config
-  min_size       = 2
-  max_size       = 3
+
+  key_name         = var.critical_addons_node_group_key_name
+  min_size         = var.critical_addons_node_group_min_size
+  max_size         = var.critical_addons_node_group_max_size
+  desired_capacity = var.critical_addons_node_group_desired_capacity
+  instance_family  = var.critical_addons_node_group_instance_family
+  instance_size    = var.critical_addons_node_group_instance_size
+  security_groups  = var.critical_addons_node_group_security_groups
+
   zone_awareness = false
   taints = {
     "CriticalAddonsOnly" = "true:NoSchedule"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -157,12 +157,6 @@ variable "critical_addons_node_group_min_size" {
   description = "The minimum number of instances that will be launched by this group, if not a multiple of the number of AZs in the group, may be rounded up"
 }
 
-variable "critical_addons_node_group_desired_capacity" {
-  type        = number
-  default     = 1
-  description = "The number of Amazon EC2 instances that should be running in the group."
-}
-
 variable "critical_addons_node_group_instance_size" {
   type        = string
   default     = "large"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -133,3 +133,44 @@ variable "dns_cluster_ip" {
   default     = ""
   description = "Overrides the IP address to use for DNS queries within the cluster. Defaults to 10.100.0.10 or 172.20.0.10 based on the VPC cidr"
 }
+
+variable "critical_addons_node_group_key_name" {
+  type    = string
+  default = ""
+}
+
+variable "critical_addons_node_group_security_groups" {
+  type        = list(string)
+  default     = []
+  description = "Additional security groups for the nodes"
+}
+
+variable "critical_addons_node_group_max_size" {
+  type        = number
+  default     = 3
+  description = "The maximum number of instances that will be launched by this group, if not a multiple of the number of AZs in the group, may be rounded down"
+}
+
+variable "critical_addons_node_group_min_size" {
+  type        = number
+  default     = 2
+  description = "The minimum number of instances that will be launched by this group, if not a multiple of the number of AZs in the group, may be rounded up"
+}
+
+variable "critical_addons_node_group_desired_capacity" {
+  type        = number
+  default     = 1
+  description = "The number of Amazon EC2 instances that should be running in the group."
+}
+
+variable "critical_addons_node_group_instance_size" {
+  type        = string
+  default     = "large"
+  description = "The size of instances in this node group"
+}
+
+variable "critical_addons_node_group_instance_family" {
+  type        = string
+  default     = "general_purpose"
+  description = "The family of instances that this group will launch, should be one of: memory_optimized, general_purpose, compute_optimized or burstable. Defaults to general_purpose"
+}


### PR DESCRIPTION
## Background

It's handy if we can change the configurations of the `critical-addon` node group and `aws_autoscaling_group` based on purposes to use EKS clusters. For example, I don't need huge instances for the `critical-addons` node group when EKS clusters are used for research purposes and want to change the value of `mix_size` and `max_size` for the `asg_node_group` module.

## Changes

* Add variables for `critical-addon` asg_node_group to the cluster module 