### PR TITLE
Fix upgrade to 1.16 forcing recreation.

### DIFF
--- a/modules/cluster/security_groups.tf
+++ b/modules/cluster/security_groups.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "control_plane" {
   count = var.legacy_security_groups ? 1 : 0
 
   name        = "eks-control-plane-${var.name}"
-  description = "This security group exists to avoid recreating an EKS cluster, please do not use"
+  description = "Cluster communication with worker nodes"
   vpc_id      = var.vpc_config.vpc_id
 
   egress {


### PR DESCRIPTION
When upgrading a cluster from 1.15 with legacy_security_groups = true
the description change to the legacy control_plane explaining why
this still existed forces the security group to be recreated.
This forces the cluster and a number of other resources to also be
recreated.

This change reverts the description to it's previous value to avoid that
recreation.