### PR TITLE
Fix exposing kube-proxy metrics

### DIFF
--- a/modules/cluster/addons/kube-proxy.yaml
+++ b/modules/cluster/addons/kube-proxy.yaml
@@ -1,3 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    eks.amazonaws.com/component: kube-proxy
+    k8s-app: kube-proxy
+  name: kube-proxy-config
+  namespace: kube-system
+data:
+  config: |-
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: 0
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      excludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    kind: KubeProxyConfiguration
+    metricsBindAddress: 0.0.0.0:10249
+    mode: "iptables"
+    nodePortAddresses: null
+    oomScoreAdj: -998
+    portRange: ""
+    resourceContainer: ""
+    udpIdleTimeout: 250ms
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -5,6 +53,7 @@ metadata:
     eks.amazonaws.com/component: kube-proxy
     k8s-app: kube-proxy
   name: kube-proxy
+  namespace: kube-system
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -32,7 +81,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config --metrics-bind-address=0.0.0.0
+        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config
         image: 602401143452.dkr.ecr.${aws_region}.amazonaws.com/eks/kube-proxy:v1.16.8
         imagePullPolicy: IfNotPresent
         name: kube-proxy


### PR DESCRIPTION
When kube-proxy is configured with a config file, trying to change
settings with a cmd flag doesn't work.

This pulls in the eks provisioned config-map and changes
`metricsBindAddress` from `127.0.0.1:10249` to `0.0.0.0:10249`