### PR TITLE
Specify true for IGNORE_DAEMON_SETS in aws-node-termination-handler manifest

### DIFF
--- a/modules/cluster/addons/aws-node-termination-handler.yaml
+++ b/modules/cluster/addons/aws-node-termination-handler.yaml
@@ -223,7 +223,7 @@ spec:
           - name: DELETE_LOCAL_DATA
             value: "true"
           - name: IGNORE_DAEMON_SETS
-            value: ""
+            value: "true"
           - name: GRACE_PERIOD
             value: ""
           - name: POD_TERMINATION_GRACE_PERIOD


### PR DESCRIPTION
## Change

* Specify `IGNORE_DAEMON_SETS=true` for aws-node-termination-handler 

## Background

  aws-node-termination-handler behaves as follows when it gets spot interruption and EC2 maintenance events.

  * if `--ignore-daemon-sets` is specified and the value is `true`, aws-node-termination-handler ignores DaemonSet and drains other pods (`kubectl drain --ignore-daemon-sets`)
  * if `--ignore-daemon-sets` is specified and the value is `false`, aws-node-termination-handler drains all pods. If there are DaemonSets, the drain for all pods does not happen (`kubectl drain`)
  * if `--ignore-daemon-sets` is not specified and `IGNORE_DAEMON_SETS` is not passed, aws-node-termination-handler ignores DaemonSet and drains other pods (`kubectl drain --ignore-daemon-sets`)
  * if `--ignore-daemon-sets` is not specified and `IGNORE_DAEMON_SETS=true` is passed, aws-node-termination-handler ignores DaemonSet and drains other pods (`kubectl drain --ignore-daemon-sets`)
  * if `--ignore-daemon-sets` is not specified and `IGNORE_DAEMON_SETS=false` is passed, aws-node-termination-handler drains all pods. If there are DaemonSets, the drain for all pods does not happen (`kubectl drain`)
  * if `--ignore-daemon-sets` is not specified and `IGNORE_DAEMON_SETS=ANY_VALUE_EXCEPT_FRO_TRUE_AND_FALSE` is passed, aws-node-termination-handler drains all pods. If there are DaemonSets, the drain for all pods does not happen (`kubectl drain`)

  Currently `IGNORE_DAEMON_SETS` is empty and `--ignore-daemon-sets` is not specified. Thus, aws-node-termination-handler tries to ignore DaemonSet. This is difficult to understand and `IGNORE_DAEMON_SETS` should have an explicit value.

## Related information

* Code: https://github.com/takanabe/aws-node-termination-handler/blob/master/pkg/config/config.go#L108-L108