### PR TITLE
Adds the ignoreDaemonSets value to the helm config for aws-node-termination-handler

### DIFF
--- a/modules/cluster/addons/helm/aws-node-termination-handler.yaml
+++ b/modules/cluster/addons/helm/aws-node-termination-handler.yaml
@@ -3,3 +3,4 @@ tolerations:
 deleteLocalData: true
 enableSpotInterruptionDraining: true
 enableScheduledEventDraining: true
+ignoreDaemonSets: true


### PR DESCRIPTION
This option was already changed in the generated manifest in #126 this
change just avoids undoing that change when we run `hack/generate_addons.sh`

FYI: @takanabe