### PR TITLE
ALB Ingress Controller

### DIFF
--- a/.github/actions/terratest/entrypoint.sh
+++ b/.github/actions/terratest/entrypoint.sh
@@ -1,4 +1,6 @@
-#!/bin/sh -l
+#!/bin/bash
+
+set -euo pipefail
 
 # If the terraform version is specified install the correct one
 tfenv install || true

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -14,6 +14,7 @@ module "cluster" {
 
   envelope_encryption_enabled = false
   metrics_server              = true
+  aws_alb_ingress_controller  = true
   aws_ebs_csi_driver          = var.aws_ebs_csi_driver
 
   critical_addons_node_group_key_name = "development"

--- a/hack/generate_addons.sh
+++ b/hack/generate_addons.sh
@@ -24,3 +24,4 @@ helm_template nvdp nvidia-device-plugin 0.6.0
 curl -o $ADDONS_DIR/kustomize/overlays/metrics-server/resources/metrics-server.yaml -L https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
 kustomize_build metrics-server
 kustomize_build aws-ebs-csi-driver
+kustomize_build aws-alb-ingress-controller

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 export AWS_ROLE_ARN="arn:aws:iam::214219211678:role/TerraformAWSEKSTests"
 export SKIP_cleanup_terraform=true
 

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -86,19 +86,20 @@ specify the arn of an existing key by setting `kms_cmk_arn`
 ## Cluster critical add-ons
 
 
-| addon | variable | default |
-|-------|----------|---------|
-| [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) | `cluster_autoscaler` | ✅ enabled |
-| [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) | `aws_node_termination_handler` | ✅ enabled |
-| [NVIDIA device plugin for Kubernetes](https://github.com/NVIDIA/k8s-device-plugin) | `nvidia_device_plugin` | ✅ enabled (but only schedules to gpu nodes) |
-| [Prometheus Node Exporter](https://github.com/prometheus/node_exporter) | `prometheus_node_exporter` | ❌ disabled |
-| [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server) | `metrics_server` | ❌ disabled |
-| [Amazon Elastic Block Store (EBS) CSI driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/) | `aws_ebs_csi_driver` | ❌ disabled |
+| addon | variable | default | iam role variable |
+|-------|----------|---------|-------------------|
+| [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) | `cluster_autoscaler` | ✅ enabled | `cluster_autoscaler_iam_role_arn` |
+| [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) | `aws_node_termination_handler` | ✅ enabled ||
+| [NVIDIA device plugin for Kubernetes](https://github.com/NVIDIA/k8s-device-plugin) | `nvidia_device_plugin` | ✅ enabled (but only schedules to gpu nodes) ||
+| [Prometheus Node Exporter](https://github.com/prometheus/node_exporter) | `prometheus_node_exporter` | ❌ disabled ||
+| [Kubernetes Metrics Server](https://github.com/kubernetes-sigs/metrics-server) | `metrics_server` | ❌ disabled ||
+| [Amazon Elastic Block Store (EBS) CSI driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/) | `aws_ebs_csi_driver` | ❌ disabled | `aws_ebs_csi_driver_iam_role_arn` |
+| [AWS ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) | `aws_alb_ingress_controller` | ❌ disabled | `aws_alb_ingress_controller_iam_role_arn` |
 
 Note that setting these variables to false will not remove provisioned add-ons from an existing cluster.
 
-By default if `cluster_autoscaler` is enabled an IAM role is provisioned to provide the appropriate permissions to alter managed auto scaling groups.
-If you wish to manage this IAM role externally you should set `cluster_autoscaler_iam_role_arn`
+Some addons require an IAM role in order to provide the appropriate permissions to read or modify AWS resources.
+If enabled these addons will provision an IAM role for this purpose.
 
-By default if `aws_ebs_csi_driver` is enabled an IAM role is provisioned to provide the appropriate permissions.
-If you wish to manage this IAM role externally you should set `aws_ebs_csi_driver_iam_role_arn`
+If you wish to avoid this, for example because you manage IAM roles with some other external process, you may specify an IAM role ARN for the addon to assume,
+and the module will skip provisioning an IAM role.

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -127,7 +127,7 @@ module "aws_alb_ingress_controller" {
   manifest = templatefile(
     "${path.module}/addons/aws-alb-ingress-controller.yaml",
     {
-      iam_role_arn = local.aws_alb_ingress_contoller_iam_role_arn,
+      iam_role_arn = local.aws_alb_ingress_controller_iam_role_arn,
       cluster_name = var.name,
     }
   )

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -119,3 +119,16 @@ module "aws_ebs_csi_driver" {
     { iam_role_arn = local.aws_ebs_csi_driver_iam_role_arn }
   )
 }
+
+module "aws_alb_ingress_controller" {
+  source = "./kubectl"
+  config = local.config
+  apply  = var.aws_alb_ingress_controller
+  manifest = templatefile(
+    "${path.module}/addons/aws-alb-ingress-controller.yaml",
+    {
+      iam_role_arn = local.aws_alb_ingress_contoller_iam_role_arn,
+      cluster_name = var.name,
+    }
+  )
+}

--- a/modules/cluster/addons/aws-alb-ingress-controller.yaml
+++ b/modules/cluster/addons/aws-alb-ingress-controller.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: ${iam_role_arn}
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+rules:
+- apiGroups:
+  - ""
+  - extensions
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - ingresses
+  - ingresses/status
+  - services
+  - pods/status
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  - extensions
+  resources:
+  - nodes
+  - pods
+  - secrets
+  - services
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+- kind: ServiceAccount
+  name: alb-ingress-controller
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alb-ingress-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alb-ingress-controller
+    spec:
+      containers:
+      - args:
+        - --cluster-name=${cluster_name}
+        env: null
+        image: docker.io/amazon/aws-alb-ingress-controller:v1.1.9
+        name: alb-ingress-controller
+      serviceAccountName: alb-ingress-controller

--- a/modules/cluster/addons/aws-alb-ingress-controller.yaml
+++ b/modules/cluster/addons/aws-alb-ingress-controller.yaml
@@ -80,6 +80,7 @@ spec:
     spec:
       containers:
       - args:
+        - --ingress-class=alb
         - --cluster-name=${cluster_name}
         env: null
         image: docker.io/amazon/aws-alb-ingress-controller:v1.1.9

--- a/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/deployment_args.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/deployment_args.yaml
@@ -9,4 +9,5 @@ spec:
       containers:
       - name: alb-ingress-controller
         args:
+          - --ingress-class=alb
           - --cluster-name=${cluster_name}

--- a/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/deployment_args.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/deployment_args.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alb-ingress-controller
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: alb-ingress-controller
+        args:
+          - --cluster-name=${cluster_name}

--- a/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/eks_iam_for_sa.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/eks_iam_for_sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alb-ingress-controller
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: ${iam_role_arn}

--- a/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/kustomization.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-alb-ingress-controller/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- github.com/kubernetes-sigs/aws-alb-ingress-controller/docs/examples/?ref=v1.1.9
+patchesStrategicMerge:
+- eks_iam_for_sa.yaml
+- deployment_args.yaml

--- a/modules/cluster/aws_alb_ingress_controller_iam.tf
+++ b/modules/cluster/aws_alb_ingress_controller_iam.tf
@@ -1,0 +1,184 @@
+locals {
+  aws_alb_ingress_controller_iam_role_count = length(var.aws_alb_ingress_controller_iam_role_arn) == 0 && var.aws_alb_ingress_controller ? 1 : 0
+  aws_alb_ingress_controller_iam_role_arn   = length(var.aws_alb_ingress_controller_iam_role_arn) > 0 ? var.aws_alb_ingress_controller_iam_role_arn : join("", aws_iam_role.aws_alb_ingress_controller.*.arn)
+}
+
+data "aws_iam_policy_document" "aws_alb_ingress_controller_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.cluster_oidc.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:alb-ingress-controller"]
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.cluster_oidc.arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_alb_ingress_controller" {
+  count                = local.aws_alb_ingress_controller_iam_role_count
+  name                 = "EksALBIngressController-${var.name}"
+  assume_role_policy   = data.aws_iam_policy_document.aws_alb_ingress_controller_assume_role_policy.json
+  permissions_boundary = var.aws_alb_ingress_controller_iam_permissions_boundary
+}
+
+# https://github.com/kubernetes-sigs/aws-alb-ingress-controller/blob/v1.1.9/docs/examples/iam-policy.json
+data "aws_iam_policy_document" "aws_alb_ingress_controller_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "acm:DescribeCertificate",
+      "acm:ListCertificates",
+      "acm:GetCertificate",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeAddresses",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeInternetGateways",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVpcs",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:RevokeSecurityGroupIngress"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "elasticloadbalancing:AddListenerCertificates",
+      "elasticloadbalancing:AddTags",
+      "elasticloadbalancing:CreateListener",
+      "elasticloadbalancing:CreateLoadBalancer",
+      "elasticloadbalancing:CreateRule",
+      "elasticloadbalancing:CreateTargetGroup",
+      "elasticloadbalancing:DeleteListener",
+      "elasticloadbalancing:DeleteLoadBalancer",
+      "elasticloadbalancing:DeleteRule",
+      "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:DescribeListenerCertificates",
+      "elasticloadbalancing:DescribeListeners",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeLoadBalancerAttributes",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:DescribeSSLPolicies",
+      "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeTargetGroupAttributes",
+      "elasticloadbalancing:DescribeTargetHealth",
+      "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:ModifyLoadBalancerAttributes",
+      "elasticloadbalancing:ModifyRule",
+      "elasticloadbalancing:ModifyTargetGroup",
+      "elasticloadbalancing:ModifyTargetGroupAttributes",
+      "elasticloadbalancing:RegisterTargets",
+      "elasticloadbalancing:RemoveListenerCertificates",
+      "elasticloadbalancing:RemoveTags",
+      "elasticloadbalancing:SetIpAddressType",
+      "elasticloadbalancing:SetSecurityGroups",
+      "elasticloadbalancing:SetSubnets",
+      "elasticloadbalancing:SetWebAcl"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:GetServerCertificate",
+      "iam:ListServerCertificates",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "cognito-idp:DescribeUserPoolClient",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "waf-regional:GetWebACLForResource",
+      "waf-regional:GetWebACL",
+      "waf-regional:AssociateWebACL",
+      "waf-regional:DisassociateWebACL",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "tag:GetResources",
+      "tag:TagResources",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "waf:GetWebACL",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "wafv2:GetWebACL",
+      "wafv2:GetWebACLForResource",
+      "wafv2:AssociateWebACL",
+      "wafv2:DisassociateWebACL",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "shield:DescribeProtection",
+      "shield:GetSubscriptionState",
+      "shield:DeleteProtection",
+      "shield:CreateProtection",
+      "shield:DescribeSubscription",
+      "shield:ListProtections",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "aws_alb_ingress_controller" {
+  count  = local.aws_alb_ingress_controller_iam_role_count
+  name   = "aws_alb_ingress_controller"
+  role   = aws_iam_role.aws_alb_ingress_controller[0].id
+  policy = data.aws_iam_policy_document.aws_alb_ingress_controller_policy.json
+}

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -108,7 +108,7 @@ variable "aws_alb_ingress_controller" {
   description = "Should the ALB Ingress Controller be deployed"
 }
 
-variable "aws_alb_ingress_contoller_iam_role_arn" {
+variable "aws_alb_ingress_controller_iam_role_arn" {
   type        = string
   default     = ""
   description = "The IAM role for the ALB Ingress Controller, if omitted then an IAM role will be created"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -102,6 +102,24 @@ variable "aws_ebs_csi_driver_iam_permissions_boundary" {
   description = "The ARN of the policy that is used to set the permissions boundary for the role."
 }
 
+variable "aws_alb_ingress_controller" {
+  type        = bool
+  default     = false
+  description = "Should the ALB Ingress Controller be deployed"
+}
+
+variable "aws_alb_ingress_contoller_iam_role_arn" {
+  type        = string
+  default     = ""
+  description = "The IAM role for the ALB Ingress Controller, if omitted then an IAM role will be created"
+}
+
+variable "aws_alb_ingress_controller_iam_permissions_boundary" {
+  type        = string
+  default     = ""
+  description = "The ARN of the policy that is used to set the permissions boundary for the role."
+}
+
 variable "pv_fstype" {
   type        = string
   default     = "ext4"

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -67,6 +69,7 @@ func TestTerraformAwsEksCluster(t *testing.T) {
 			"aws_ebs_csi_driver": true,
 		})
 		validateStorage(t, kubeconfig)
+		validateIngress(t, kubeconfig)
 	})
 }
 
@@ -325,4 +328,84 @@ spec:
       - name: persistent-storage
         persistentVolumeClaim:
           claimName: ebs-claim
+`
+
+func validateIngress(t *testing.T, kubeconfig string) {
+	namespace := strings.ToLower(random.UniqueId())
+	kubectlOptions := k8s.NewKubectlOptions("", kubeconfig, namespace)
+	workload := fmt.Sprintf(EXAMPLE_INGRESS_WORKLOAD, namespace, namespace, namespace, namespace)
+	defer k8s.KubectlDeleteFromString(t, kubectlOptions, workload)
+	k8s.KubectlApplyFromString(t, kubectlOptions, workload)
+	url := retry.DoWithRetry(t, "get ingress url", 10, 10*time.Second, func() (string, error) {
+		ingress := k8s.GetIngress(t, kubectlOptions, "echoserver")
+		if len(ingress.Status.LoadBalancer.Ingress) == 0 {
+			return "", errors.New("ingress not ready")
+		}
+		return fmt.Sprintf("http://%s", ingress.Status.LoadBalancer.Ingress[0].Hostname), nil
+	})
+	validation := func(status int, _ string) bool {
+		return status == 200
+	}
+	http_helper.HttpGetWithRetryWithCustomValidation(t, url, nil, 20, time.Minute, validation)
+}
+
+const EXAMPLE_INGRESS_WORKLOAD = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoserver
+  namespace: %s
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: echoserver
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echoserver
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: echoserver
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: echoserver
+    spec:
+      containers:
+      - image: gcr.io/google_containers/echoserver:1.4
+        imagePullPolicy: Always
+        name: echoserver
+        ports:
+        - containerPort: 8080
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: echoserver
+  namespace: %s
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            backend:
+              serviceName: echoserver
+              servicePort: 80
 `


### PR DESCRIPTION
This PR introduces support for provisioning the ALB ingress controller.

For now the default is to not provision this component, based on the discussions in #87 as some cluster admins might prefer to use another implementation.

It can be enabled by setting `aws_alb_ingress_controller = true` on the Cluster module.

Fixes #87