### PR TITLE
Adds node region and zone topology labels to autoscaler template

### DIFF
--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -35,6 +35,8 @@ data "aws_ami" "image" {
   }
 }
 
+data "aws_region" "current" {}
+
 data "template_file" "cloud_config" {
   template = file("${path.module}/cloud_config.tpl")
   vars = {
@@ -139,6 +141,36 @@ resource "aws_autoscaling_group" "nodes" {
     key                 = "Role"
     value               = "eks-node"
     propagate_at_launch = true
+  }
+
+  tag {
+    key = "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com"
+    value = each.key
+    propagate_at_launch = false
+  }
+
+  tag {
+    key = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/zone"
+    value = each.key
+    propagate_at_launch = false
+  }
+
+  tag {
+    key = "k8s.io/cluster-autoscaler/node-template/label/failure-domain.beta.kubernetes.io/zone"
+    value = each.key
+    propagate_at_launch = false
+  }
+
+  tag {
+    key = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/region"
+    value = data.aws_region.current.name
+    propagate_at_launch = false
+  }
+
+  tag {
+    key = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/region"
+    value = data.aws_region.current.name
+    propagate_at_launch = false
   }
 
   dynamic "tag" {

--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -144,7 +144,7 @@ resource "aws_autoscaling_group" "nodes" {
   }
 
   tag {
-    key = "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com"
+    key = "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone"
     value = each.key
     propagate_at_launch = false
   }

--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -144,32 +144,32 @@ resource "aws_autoscaling_group" "nodes" {
   }
 
   tag {
-    key = "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone"
-    value = each.key
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone"
+    value               = each.key
     propagate_at_launch = false
   }
 
   tag {
-    key = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/zone"
-    value = each.key
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/zone"
+    value               = each.key
     propagate_at_launch = false
   }
 
   tag {
-    key = "k8s.io/cluster-autoscaler/node-template/label/failure-domain.beta.kubernetes.io/zone"
-    value = each.key
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/failure-domain.beta.kubernetes.io/zone"
+    value               = each.key
     propagate_at_launch = false
   }
 
   tag {
-    key = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/region"
-    value = data.aws_region.current.name
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/region"
+    value               = data.aws_region.current.name
     propagate_at_launch = false
   }
 
   tag {
-    key = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/region"
-    value = data.aws_region.current.name
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/topology.kubernetes.io/region"
+    value               = data.aws_region.current.name
     propagate_at_launch = false
   }
 

--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -143,10 +143,13 @@ resource "aws_autoscaling_group" "nodes" {
     propagate_at_launch = true
   }
 
-  tag {
-    key                 = "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone"
-    value               = each.key
-    propagate_at_launch = false
+  dynamic "tag" {
+    for_each = var.cluster_config.aws_ebs_csi_driver ? { "k8s.io/cluster-autoscaler/node-template/label/topology.ebs.csi.aws.com/zone" = each.key } : {}
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = false
+    }
   }
 
   tag {

--- a/modules/asg_node_group/variables.tf
+++ b/modules/asg_node_group/variables.tf
@@ -7,6 +7,7 @@ variable "cluster_config" {
     node_instance_profile = string
     tags                  = map(string)
     dns_cluster_ip        = string
+    aws_ebs_csi_driver    = bool
   })
 }
 

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -9,6 +9,7 @@ locals {
     node_instance_profile = var.iam_config.node_role
     tags                  = var.tags
     dns_cluster_ip        = local.dns_cluster_ip
+    aws_ebs_csi_driver    = var.aws_ebs_csi_driver
   }
 }
 


### PR DESCRIPTION
This will assist cluster autoscaler in choosing the right ASG to scale
up when zone is important, e.g. when handling EBS volumes or zone
(anti)affinity!