### PR TITLE
Update coredns configuration

### DIFF
--- a/modules/cluster/addons/coredns.yaml
+++ b/modules/cluster/addons/coredns.yaml
@@ -64,14 +64,19 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+          lameduck 5s
+        }
+        ready
         kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
-          upstream
           fallthrough in-addr.arpa ip6.arpa
+          ttl 30
         }
         prometheus :9153
-        forward . /etc/resolv.conf
+        forward . /etc/resolv.conf {
+          max_concurrent 1000
+        }
         cache 30
         loop
         reload


### PR DESCRIPTION
The upstream option was previously ignored, but has been removed in
version 1.7.0

Also sets healthcheck lameduck option inline with kubernetes defaults