### PR TITLE
Use pre-provisioned environment

### DIFF
--- a/.github/actions/terratest/entrypoint.sh
+++ b/.github/actions/terratest/entrypoint.sh
@@ -5,7 +5,5 @@ set -euo pipefail
 # If the terraform version is specified install the correct one
 tfenv install || true
 
-source /assume_role.sh
-
 cd test
 go test -v -timeout 90m "$@" | grep -v "constructing many client instances from the same exec auth config"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,30 @@ jobs:
           tf_actions_subcommand: 'fmt'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Terraform Init cluster'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.20
+          tf_actions_subcommand: 'init'
+          tf_actions_working_dir: 'examples/cluster'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-skip-session-tagging: true
+      - name: 'Terraform Validate cluster'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.20
+          tf_actions_subcommand: 'validate'
+          tf_actions_working_dir: 'examples/cluster'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   cluster-test:
     name: Test cluster module
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
@@ -29,12 +53,15 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@master
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-skip-session-tagging: true
       - name: 'Terratest'
         uses: ./.github/actions/terratest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ROLE_ARN: "arn:aws:iam::214219211678:role/TerraformAWSEKSTests"
         with:
           args: "-run TestTerraformAwsEksCluster"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,22 +22,6 @@ jobs:
           tf_actions_subcommand: 'fmt'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Terraform Init cluster'
-        uses: hashicorp/terraform-github-actions@master
-        with:
-          tf_actions_version: 0.12.20
-          tf_actions_subcommand: 'init'
-          tf_actions_working_dir: 'examples/cluster'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Terraform Validate cluster'
-        uses: hashicorp/terraform-github-actions@master
-        with:
-          tf_actions_version: 0.12.20
-          tf_actions_subcommand: 'validate'
-          tf_actions_working_dir: 'examples/cluster'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   cluster-test:
     name: Test cluster module
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/examples/cluster/environment.tf
+++ b/examples/cluster/environment.tf
@@ -3,9 +3,11 @@
 # This is in order to simulate launching a cluster in an existing VPC!
 
 data "terraform_remote_state" "environment" {
-  backend = "local"
+  backend = "s3"
 
   config = {
-    path = "${path.module}/environment/terraform.tfstate"
+    bucket = "cookpad-terraform-aws-eks-testing"
+    key    = "test-environment"
+    region = "us-east-1"
   }
 }

--- a/examples/cluster/environment/backend.tf
+++ b/examples/cluster/environment/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "cookpad-terraform-aws-eks-testing"
+    key            = "test-environment"
+    region         = "us-east-1"
+    dynamodb_table = "terraform_locks"
+  }
+}

--- a/examples/cluster/environment/main.tf
+++ b/examples/cluster/environment/main.tf
@@ -7,14 +7,11 @@ provider "aws" {
 module "vpc" {
   source = "../../../modules/vpc"
 
-  name               = var.cluster_name
+  name               = var.vpc_name
   cidr_block         = var.cidr_block
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1d"]
 }
 
 module "iam" {
   source = "../../../modules/iam"
-
-  service_role_name = "eksServiceRole-${var.cluster_name}"
-  node_role_name    = "EKSNode-${var.cluster_name}"
 }

--- a/examples/cluster/environment/variables.tf
+++ b/examples/cluster/environment/variables.tf
@@ -1,6 +1,6 @@
-variable "cluster_name" {
+variable "vpc_name" {
   type    = string
-  default = "test-cluster"
+  default = "terraform-aws-eks-test-environment"
 }
 
 variable "cidr_block" {

--- a/hack/assume_role.sh
+++ b/hack/assume_role.sh
@@ -1,7 +1,10 @@
+#!/bin/bash
+
 unset  AWS_SESSION_TOKEN
 temp_role=$(aws sts assume-role \
                     --role-arn "$AWS_ROLE_ARN" \
                     --role-session-name "terraform-aws-eks-tests")
+
 export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq -r .Credentials.AccessKeyId)
 export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r .Credentials.SecretAccessKey)
 export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r .Credentials.SessionToken)

--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -12,5 +12,3 @@ clean() {
 
 cd examples/cluster
 clean
-cd environment
-clean

--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export AWS_ROLE_ARN="arn:aws:iam::214219211678:role/TerraformAWSEKSTests"
-source .github/actions/terratest/assume_role.sh
+source hack/assume_role.sh
 
 clean() {
   terraform destroy -refresh=false -auto-approve

--- a/hack/kubeconfig.sh
+++ b/hack/kubeconfig.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 
 export AWS_ROLE_ARN="arn:aws:iam::214219211678:role/TerraformAWSEKSTests"
-unset  AWS_SESSION_TOKEN
-temp_role=$(aws sts assume-role \
-                    --role-arn "$AWS_ROLE_ARN" \
-                    --role-session-name "terraform-aws-eks-tests")
-
-export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq -r .Credentials.AccessKeyId)
-export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r .Credentials.SecretAccessKey)
-export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r .Credentials.SessionToken)
+source hack/assume_role.sh
 
 cd examples/cluster
 aws eks update-kubeconfig --name $(terraform output cluster_name) --role-arn $AWS_ROLE_ARN

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 export AWS_ROLE_ARN="arn:aws:iam::214219211678:role/TerraformAWSEKSTests"
-export SKIP_cleanup_terraform=true
+source hack/assume_role.sh
 
-source .github/actions/terratest/assume_role.sh
+export SKIP_cleanup_terraform=true
 
 cd test
 go test -v -timeout 90m -run TestTerraformAwsEksCluster | grep -v "constructing many client instances from the same exec auth config"

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -35,18 +35,12 @@ func TestTerraformAwsEksCluster(t *testing.T) {
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
 	defer test_structure.RunTestStage(t, "cleanup_terraform", func() {
 		cleanupTerraform(t, workingDir)
-		removeSecurityGroups(t, environmentDir)
-		cleanupTerraform(t, environmentDir)
 	})
 
 	test_structure.RunTestStage(t, "deploy_cluster", func() {
 		uniqueId := random.UniqueId()
 		clusterName := fmt.Sprintf("terraform-aws-eks-testing-%s", uniqueId)
-		vpcCidr := aws.GetRandomPrivateCidrBlock(18)
-		deployTerraform(t, environmentDir, map[string]interface{}{
-			"cluster_name": clusterName,
-			"cidr_block":   vpcCidr,
-		})
+		deployTerraform(t, environmentDir, map[string]interface{}{})
 		deployTerraform(t, workingDir, map[string]interface{}{
 			"cluster_name":       clusterName,
 			"aws_ebs_csi_driver": false,

--- a/test/common.go
+++ b/test/common.go
@@ -18,10 +18,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 func deployTerraform(t *testing.T, workingDir string, vars map[string]interface{}) {
@@ -61,71 +57,6 @@ func cleanupTerraform(t *testing.T, workingDir string) {
 	terraformOptions := test_structure.LoadTerraformOptions(t, workingDir)
 	terraform.Destroy(t, terraformOptions)
 	test_structure.CleanupTestDataFolder(t, workingDir)
-}
-
-func removeSecurityGroups(t *testing.T, workingDir string) {
-	terraformOptions := test_structure.LoadTerraformOptions(t, workingDir)
-	vpcId := terraform.Output(t, terraformOptions, "vpc_id")
-	client := ec2.New(session.New(&aws.Config{Region: aws.String("us-east-1")}))
-	securityGroups(t, client, vpcId, func(sg *ec2.SecurityGroup) {
-		revokeRules(t, client, sg)
-	})
-	securityGroups(t, client, vpcId, func(sg *ec2.SecurityGroup) {
-		deleteSecurityGroup(t, client, sg)
-	})
-
-}
-
-func securityGroups(t *testing.T, client *ec2.EC2, vpcId string, function func(*ec2.SecurityGroup)) {
-	input := &ec2.DescribeSecurityGroupsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("vpc-id"),
-				Values: []*string{
-					aws.String(vpcId),
-				},
-			},
-		},
-	}
-	err := client.DescribeSecurityGroupsPages(
-		input,
-		func(page *ec2.DescribeSecurityGroupsOutput, lastPage bool) bool {
-			for _, sg := range page.SecurityGroups {
-				function(sg)
-			}
-			return !lastPage
-		},
-	)
-	if err != nil {
-		logger.Log(t, err.Error())
-	}
-}
-
-func deleteSecurityGroup(t *testing.T, client *ec2.EC2, sg *ec2.SecurityGroup) {
-	if *sg.GroupName == "default" {
-		return
-	}
-	logger.Log(t, "Deleting security group:", *sg.GroupName, *sg.GroupId)
-	deleteInput := &ec2.DeleteSecurityGroupInput{
-		GroupId: aws.String(*sg.GroupId),
-	}
-	_, err := client.DeleteSecurityGroup(deleteInput)
-	if err != nil {
-		logger.Log(t, err.Error())
-	}
-}
-
-func revokeRules(t *testing.T, client *ec2.EC2, sg *ec2.SecurityGroup) {
-	for _, permission := range sg.IpPermissions {
-		input := &ec2.RevokeSecurityGroupIngressInput{
-			GroupId:       aws.String(*sg.GroupId),
-			IpPermissions: []*ec2.IpPermission{permission},
-		}
-		_, err := client.RevokeSecurityGroupIngress(input)
-		if err != nil {
-			logger.Log(t, err.Error())
-		}
-	}
 }
 
 func writeKubeconfig(t *testing.T, opts ...string) string {


### PR DESCRIPTION
We are seeing a lot of test failures relating to cleanup of the network
components.

This change means that we will pre-provision the VPC used in the tests
and re-use it for each test run.