### PR TITLE
Update tests for new kube-bench format

### DIFF
--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -472,9 +472,13 @@ func validateKubeBench(t *testing.T, kubeconfig string) {
 	err = json.Unmarshal([]byte(output), &resultWrapper)
 	require.NoError(t, err)
 	result := resultWrapper.Totals
-	assert.Equal(t, 0, result.TotalFail)
+	if !assert.Equal(t, 0, result.TotalFail) {
+		fmt.Printf(`non-zero total_fail: %s`, output)
+	}
 	// https://github.com/awslabs/amazon-eks-ami/pull/391
-	assert.LessOrEqual(t, result.TotalWarn, 1)
+	if !assert.LessOrEqual(t, result.TotalWarn, 1) {
+		fmt.Printf(`>=1 total_warn: %s`, output)
+	}
 }
 
 type KubeBenchResult struct {

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -468,20 +468,24 @@ func validateKubeBench(t *testing.T, kubeconfig string) {
 	WaitUntilPodsSucceeded(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=kube-bench"}, 1, 30, 5*time.Second)
 	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "logs", "-l", "app=kube-bench")
 	require.NoError(t, err)
-	results := make([]KubeBenchResult, 1)
-	err = json.Unmarshal([]byte(output), &results)
+	resultWrapper := KubeBenchResult{}
+	err = json.Unmarshal([]byte(output), &resultWrapper)
 	require.NoError(t, err)
-	result := results[0]
+	result := resultWrapper.Totals
 	assert.Equal(t, result.TotalFail, 0)
 	// https://github.com/awslabs/amazon-eks-ami/pull/391
 	assert.LessOrEqual(t, result.TotalWarn, 1)
 }
 
 type KubeBenchResult struct {
-	TotalPass int `json:total_pass`
-	TotalFail int `json:total_fail`
-	TotalWarn int `json:total_warn`
-	TotalInfo int `json:total_info`
+	Totals KubeBenchResultTotals `json:"Totals"`
+}
+
+type KubeBenchResultTotals struct {
+	TotalPass int `json:"total_pass"`
+	TotalFail int `json:"total_fail"`
+	TotalWarn int `json:"total_warn"`
+	TotalInfo int `json:"total_info"`
 }
 
 const KUBEBENCH_MANIFEST = `---

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -472,7 +472,7 @@ func validateKubeBench(t *testing.T, kubeconfig string) {
 	err = json.Unmarshal([]byte(output), &resultWrapper)
 	require.NoError(t, err)
 	result := resultWrapper.Totals
-	assert.Equal(t, result.TotalFail, 0)
+	assert.Equal(t, 0, result.TotalFail)
 	// https://github.com/awslabs/amazon-eks-ami/pull/391
 	assert.LessOrEqual(t, result.TotalWarn, 1)
 }


### PR DESCRIPTION
The format of kube-bench output changed from 0.4.0 to 0.5.0.

DriveBy: Fix json tag names - this might result in *different* failures
as everything might not get the default 0 value.