### PR TITLE
rename example readonly group to avoid confusion

### DIFF
--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -59,7 +59,7 @@ module "cluster" {
     {
       username = "ReadOnlyUser"
       role_arn = "arn:aws:iam::123456789000:role/ReadonlyUser"
-      groups   = ["system:basic-user"]
+      groups   = ["myreadonlygroup"]
     }
   ]
 


### PR DESCRIPTION
This documentation caused some confusion for a user. Unlike the `system:masters` group which has cluster admin permissions from the `cluster-admin` ClusterRoleBinding,  `system:basic-user` is not a valid group without user-specified custom RBAC. `system:basic-user` is a ClusterRole with the following definition 
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    rbac.authorization.kubernetes.io/autoupdate: "true"
  creationTimestamp: "2019-07-24T13:34:08Z"
  labels:
    kubernetes.io/bootstrapping: rbac-defaults
  name: system:basic-user
  resourceVersion: "68"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/system%3Abasic-user
  uid: b6b451d4-ae17-11e9-997d-12781aca2b9a
rules:
- apiGroups:
  - authorization.k8s.io
  resources:
  - selfsubjectaccessreviews
  - selfsubjectrulesreviews
  verbs:
  - create
```
so this example would not work if you tried it out.

