### PR TITLE
add release automation github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      versionName:
+        description: 'Release name'
+        required: true
+      releaseTag:
+        description: 'Version tag (format {major}.{minor}.{patch}-{optional-rc#})'
+        required: true
+      releaseBody:
+        description: 'Release body text'
+        required: true
+      isRC:
+        description: 'Is prerelease? (Set true for release candidates) (true/false)'
+        required: true
+jobs:
+  createrelease:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v2.3.4
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.releaseTag }}
+          release_name: Release ${{ github.event.inputs.versionName }}
+          body: ${{ github.event.inputs.releaseBody }}
+          draft: false
+          prerelease: ${{ github.event.inputs.isRC }}
+      - name: Slack notify
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GITHUB_CHANNEL }}
+          SLACK_CHANNEL: "#k8s"
+          SLACK_USERNAME: terraform-aws-eks release bot
+          SLACK_ICON_EMOJI: ":rocket:"
+          SLACK_TITLE: 🚨 Releasing terraform-aws-eks version ${{ github.event.inputs.releaseTag }}
+          SLACK_MESSAGE: https://github.com/cookpad/terraform-aws-eks/releases/tag/${{ github.event.inputs.releaseTag }}/
+          MSG_MINIMAL: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Slack notify
         uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GITHUB_CHANNEL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: "#k8s"
           SLACK_USERNAME: terraform-aws-eks release bot
           SLACK_ICON_EMOJI: ":rocket:"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,11 +51,5 @@ We expect to cherry-pick or backport essential changes to release branches.
 
 # Release Procedure
 
-```bash
-git checkout release-<major>-<minor>
-git tag v<major>.<minor>.<patch> -m "Version <major>.<minor>.<patch>"
-git push --tags
-```
-
-* Create GitHub release https://github.com/cookpad/terraform-aws-eks/releases/new and include any release notes
+* Manually trigger the [Create Release](https://github.com/cookpad/terraform-aws-eks//actions?query=workflow%3A%22Create+Release%22) workflow - follow the [versioning guide](#versioning) when filling out the version input.
 * Check the version has been published at https://registry.terraform.io/modules/cookpad/eks/aws


### PR DESCRIPTION
Closes #149 

Github action workflow for:
- Create github release
- Notify slack for successful releases

Manually triggered workflow .

There's a lot of scope to improve this process, left to a future issue - the release body is restricted to an input  on the workflow trigger which is quite small and only single-line:
<img width="391" alt="Screenshot 2021-02-09 at 12 25 45" src="https://user-images.githubusercontent.com/4749195/107363435-0dac3c80-6ad2-11eb-9e77-114b3adff4b7.png">

It would be nice to automate the release body with a github action w/ CHANGELOG (or similar process).

Here's an example of the slack notification:
<img width="603" alt="Screenshot 2021-02-09 at 12 25 18" src="https://user-images.githubusercontent.com/4749195/107363534-33394600-6ad2-11eb-8df8-782ebcf0e836.png">
