### PR TITLE
do not run CI workflow on documentation changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 
 on:
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+
   push:
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
     branches:
       - master
       - release-*


### PR DESCRIPTION
Do not run CI on commits/PRs unless at least 1 file is not documentation.
Given CI is a bit heavy this will save time waiting for small documentation changes and will save a bit of $$