### PR TITLE
[IAM module] Fix Invalid depends_on reference error

### DIFF
--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -4,10 +4,10 @@ output "config" {
     node_role    = aws_iam_role.eks_node.name
   }
   depends_on = [
-    aws_iam_role_policy_attachment.eks_worker_node.policy_arn,
-    aws_iam_role_policy_attachment.eks_cni.policy_arn,
-    aws_iam_role_policy_attachment.ecr.policy_arn,
-    aws_iam_role_policy_attachment.eks_service_policy.policy_arn,
-    aws_iam_role_policy_attachment.eks_cluster_policy.policy_arn,
+    aws_iam_role_policy_attachment.eks_worker_node,
+    aws_iam_role_policy_attachment.eks_cni,
+    aws_iam_role_policy_attachment.ecr,
+    aws_iam_role_policy_attachment.eks_service_policy,
+    aws_iam_role_policy_attachment.eks_cluster_policy,
   ]
 }


### PR DESCRIPTION
## Background

The following error occurs while terraform plan is executed.

<details>
<summary>terraform plan</summary>

```
terraform plan
Acquiring state lock. This may take a few moments...
Releasing state lock. This may take a few moments...

Error: Invalid depends_on reference

  on .terraform/modules/eks_iam/modules/iam/outputs.tf line 7, in output "config":
   7:     aws_iam_role_policy_attachment.eks_worker_node.policy_arn,

References in depends_on must be to a whole object (resource, etc), not to an
attribute of an object.

Error: Invalid depends_on reference

  on .terraform/modules/eks_iam/modules/iam/outputs.tf line 8, in output "config":
   8:     aws_iam_role_policy_attachment.eks_cni.policy_arn,

References in depends_on must be to a whole object (resource, etc), not to an
attribute of an object.

Error: Invalid depends_on reference

  on .terraform/modules/eks_iam/modules/iam/outputs.tf line 9, in output "config":
   9:     aws_iam_role_policy_attachment.ecr.policy_arn,

References in depends_on must be to a whole object (resource, etc), not to an
attribute of an object.

Error: Invalid depends_on reference

  on .terraform/modules/eks_iam/modules/iam/outputs.tf line 10, in output "config":
  10:     aws_iam_role_policy_attachment.eks_service_policy.policy_arn,

References in depends_on must be to a whole object (resource, etc), not to an
attribute of an object.

Error: Invalid depends_on reference

  on .terraform/modules/eks_iam/modules/iam/outputs.tf line 11, in output "config":
  11:     aws_iam_role_policy_attachment.eks_cluster_policy.policy_arn,

References in depends_on must be to a whole object (resource, etc), not to an
```
</details>

To fix this invalid dependency errors, we have to pass objects instead of resouces(policy_arn.)

## Technical changes

* Pass objects instead of resouces(policy_arn) to `depends_on` argument.

## Test Environment

A clean AWS account with the following Terraform configurations.

```
$ cat main.tf
module "eks_iam" {
  source  = "cookpad/eks/aws//modules/iam"
  version = "1.17.0"
}

$ cat .terraform-version
0.14.5
```

## Terraform plan with this PR

<details>
<summary>terraform plan</summary>

```
$ terraform plan
Acquiring state lock. This may take a few moments...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.eks_iam.aws_iam_instance_profile.eks_node will be created
  + resource "aws_iam_instance_profile" "eks_node" {
      + arn         = (known after apply)
      + create_date = (known after apply)
      + id          = (known after apply)
      + name        = "EKSNode"
      + path        = "/"
      + role        = "EKSNode"
      + unique_id   = (known after apply)
    }

  # module.eks_iam.aws_iam_role.eks_node will be created
  + resource "aws_iam_role" "eks_node" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "EKSNode"
      + path                  = "/"
      + unique_id             = (known after apply)
    }

  # module.eks_iam.aws_iam_role.eks_service_role will be created
  + resource "aws_iam_role" "eks_service_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "eks.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + max_session_duration  = 3600
      + name                  = "eksServiceRole"
      + path                  = "/"
      + unique_id             = (known after apply)
    }

  # module.eks_iam.aws_iam_role_policy.set_name_tag will be created
  + resource "aws_iam_role_policy" "set_name_tag" {
      + id     = (known after apply)
      + name   = "set_name_tag"
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "ec2:CreateTags",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role   = (known after apply)
    }

  # module.eks_iam.aws_iam_role_policy_attachment.ecr will be created
  + resource "aws_iam_role_policy_attachment" "ecr" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
      + role       = "EKSNode"
    }

  # module.eks_iam.aws_iam_role_policy_attachment.eks_cluster_policy will be created
  + resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
      + role       = "eksServiceRole"
    }

  # module.eks_iam.aws_iam_role_policy_attachment.eks_cni will be created
  + resource "aws_iam_role_policy_attachment" "eks_cni" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
      + role       = "EKSNode"
    }

  # module.eks_iam.aws_iam_role_policy_attachment.eks_service_policy will be created
  + resource "aws_iam_role_policy_attachment" "eks_service_policy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
      + role       = "eksServiceRole"
    }

  # module.eks_iam.aws_iam_role_policy_attachment.eks_worker_node will be created
  + resource "aws_iam_role_policy_attachment" "eks_worker_node" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
      + role       = "EKSNode"
    }

  # module.eks_iam.aws_iam_role_policy_attachment.ssm_managed_instance_core will be created
  + resource "aws_iam_role_policy_attachment" "ssm_managed_instance_core" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
      + role       = "EKSNode"
    }

Plan: 10 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

Releasing state lock. This may take a few moments...

```
</details>