### PR TITLE
[ASG Node Group] Make EKS node name self-explanatory

### DIFF
--- a/modules/asg_node_group/cloud_config.tpl
+++ b/modules/asg_node_group/cloud_config.tpl
@@ -1,7 +1,7 @@
 ## template: jinja
 #cloud-config
-fqdn: eks-node-${cluster_name}-{{ v1.instance_id }}
+fqdn: ${node_name_prefix}-{{ v1.instance_id }}
 runcmd:
-- [aws, --region={{ v1.region }}, ec2, create-tags, --resources={{ v1.instance_id }}, "--tags=Key=Name,Value=eks-node-${cluster_name}-{{ v1.instance_id }}"]
+- [aws, --region={{ v1.region }}, ec2, create-tags, --resources={{ v1.instance_id }}, "--tags=Key=Name,Value=${node_name_prefix}-{{ v1.instance_id }}"]
 - [systemctl, restart, docker]
 - [/etc/eks/bootstrap.sh, ${cluster_name}, --kubelet-extra-args, '--node-labels=${labels} --register-with-taints="${taints}"', --dns-cluster-ip, ${dns_cluster_ip}]

--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -8,7 +8,7 @@ locals {
 
   instance_types       = length(var.instance_types) > 0 ? var.instance_types : [for instance_family in local.preset_instance_families[var.instance_family] : "${instance_family}.${var.instance_size}"]
   instance_overrides   = var.instance_lifecycle == "spot" ? local.instance_types : [local.instance_types[0]]
-  name_prefix          = replace(join("-", compact(["eks-node", var.cluster_config.name, var.name, var.instance_family, var.instance_size, var.instance_lifecycle])), "_", "-")
+  name_prefix          = replace(join("-", compact(["eks", var.cluster_config.name, var.name, var.instance_family, var.instance_size, var.instance_lifecycle])), "_", "-")
   asg_subnets          = var.zone_awareness ? { for az, subnet in var.cluster_config.private_subnet_ids : az => [subnet] } : { "multi-zone" = values(var.cluster_config.private_subnet_ids) }
   max_size             = floor(var.max_size / length(local.asg_subnets))
   min_size             = ceil(var.min_size / length(local.asg_subnets))
@@ -53,10 +53,11 @@ data "aws_region" "current" {}
 data "template_file" "cloud_config" {
   template = file("${path.module}/cloud_config.tpl")
   vars = {
-    cluster_name   = var.cluster_config.name
-    labels         = join(",", [for label, value in local.labels : "${label}=${value}"])
-    taints         = join(",", [for taint, value_effect in var.taints : "${taint}=${value_effect}"])
-    dns_cluster_ip = var.cluster_config.dns_cluster_ip
+    cluster_name     = var.cluster_config.name
+    node_name_prefix = local.name_prefix
+    labels           = join(",", [for label, value in local.labels : "${label}=${value}"])
+    taints           = join(",", [for taint, value_effect in var.taints : "${taint}=${value_effect}"])
+    dns_cluster_ip   = var.cluster_config.dns_cluster_ip
   }
 }
 


### PR DESCRIPTION
## Background 

EC2 instances used as EKS critical addons and workers have the following
name conventions.

```
eks-node-{cluster_name}-{instance_id}
```

and actual EC2 names are like

```
aws --region us-west-2 ec2 describe-instances --output json --filter "Name=instance-state-name,Values=running" --query 'Reservations[].Instances[].[Tags[?Key==`Name`].Value]'
[
    [
        [
            "eks-node-staging-i-0f0f023b78914d96d"
        ]
    ],
    [
        [
            "eks-node-staging-i-0bfd628ea84f245c1"
        ]
    ],
    [
        [
            "eks-node-staging-i-04e842972094f606c"
        ]
    ],
    [
        [
            "eks-node-staging-i-02b89112b0d523510"
        ]
    ]
]

```

In theory, we should not name serves(pets vs cattle) to identify the servers but adding metadata to EC2 instance names are sometimes useful. For example, the following names explain the type of EKS node and not the role of applications running in the node.

```
eks-{cluster_name}-{asg_node_group_name}-{instance_family}-{instance_size}-{instance_lifecycle}-{instance_id}
```
The expected EC2 name will become as follows:

```
aws --region us-west-2 ec2 describe-instances --output json --filter "Name=instance-state-name,Values=running" --query 'Reservations[].Instances[].[Tags[?Key==`Name`].Value]'

[
    [
        [
            "eks-staging-worker-burstable-nano-spot-i-09a7dc7273050d3d2"
        ]
    ],
    [
        [
            "eks-staging-worker-burstable-nano-spot-i-068db7c80fd94acc4"
        ]
    ],
    [
        [
            "eks-staging-critical-addons-burstable-small-spot-i-0a2ceda5188392458"
        ]
    ],
    [
        [
            "eks-staging-worker-burstable-nano-spot-i-0e3f3e9e16eb0b7f3"
        ]
    ]
]

```

I thought the above metadata is good to add but if we don't think they are not useful. I'd like to add metadata `worker` and `critical-addons` at least.

## Change

* Remove `node` from EC2 Name tag to make the name shorter
   * since the strings does not include valuable info
* EC2 name tags will change 
   * from `eks-node-${cluster_name}-{{ v1.instance_id }}`
   * to `eks-{cluster_name}-{asg_node_group_name}-{instance_family}-{instance_size}-{instance_lifecycle}-{instance_id}`

## Question

This change may impact the design of this module and want to get feedback from maintainers.