### PR TITLE
Use public ECR repository to bypass Dockerhub image rate limit

### DIFF
--- a/hack/generate_addons.sh
+++ b/hack/generate_addons.sh
@@ -17,7 +17,7 @@ kustomize_build() {
   kustomize build $ADDONS_DIR/kustomize/overlays/$1 > $ADDONS_DIR/$1.yaml
 }
 
-helm_template eks aws-node-termination-handler 0.10.0
+helm_template eks aws-node-termination-handler 0.13.3
 helm_template autoscaler cluster-autoscaler 1.0.4 -chart
 helm_template nvdp nvidia-device-plugin 0.7.0
 

--- a/modules/cluster/addons/aws-ebs-csi-driver.yaml
+++ b/modules/cluster/addons/aws-ebs-csi-driver.yaml
@@ -17,41 +17,27 @@ spec:
   scope: Cluster
   validation:
     openAPIV3Schema:
-      description: VolumeSnapshotClass specifies parameters that a underlying storage
-        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
-        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
-        are non-namespaced
+      description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         deletionPolicy:
-          description: deletionPolicy determines whether a VolumeSnapshotContent created
-            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
-            is deleted. Supported values are "Retain" and "Delete". "Retain" means
-            that the VolumeSnapshotContent and its physical snapshot on underlying
-            storage system are kept. "Delete" means that the VolumeSnapshotContent
-            and its physical snapshot on underlying storage system are deleted. Required.
+          description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
           enum:
           - Delete
           - Retain
           type: string
         driver:
-          description: driver is the name of the storage driver that handles this
-            VolumeSnapshotClass. Required.
+          description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         parameters:
           additionalProperties:
             type: string
-          description: parameters is a key-value map with storage driver specific
-            parameters for creating snapshots. These values are opaque to Kubernetes.
+          description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
           type: object
       required:
       - deletionPolicy
@@ -90,87 +76,47 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
-        object in the underlying storage system
+      description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
-          description: spec defines properties of a VolumeSnapshotContent created
-            by the underlying storage system. Required.
+          description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
           properties:
             deletionPolicy:
-              description: deletionPolicy determines whether this VolumeSnapshotContent
-                and its physical snapshot on the underlying storage system should
-                be deleted when its bound VolumeSnapshot is deleted. Supported values
-                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
-                and its physical snapshot on underlying storage system are kept. "Delete"
-                means that the VolumeSnapshotContent and its physical snapshot on
-                underlying storage system are deleted. In dynamic snapshot creation
-                case, this field will be filled in with the "DeletionPolicy" field
-                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
-                pre-existing snapshots, users MUST specify this field when creating
-                the VolumeSnapshotContent object. Required.
+              description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. In dynamic snapshot creation case, this field will be filled in with the "DeletionPolicy" field defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For pre-existing snapshots, users MUST specify this field when creating the VolumeSnapshotContent object. Required.
               enum:
               - Delete
               - Retain
               type: string
             driver:
-              description: driver is the name of the CSI driver used to create the
-                physical snapshot on the underlying storage system. This MUST be the
-                same as the name returned by the CSI GetPluginName() call for that
-                driver. Required.
+              description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
               type: string
             source:
-              description: source specifies from where a snapshot will be created.
-                This field is immutable after creation. Required.
+              description: source specifies from where a snapshot will be created. This field is immutable after creation. Required.
               properties:
                 snapshotHandle:
-                  description: snapshotHandle specifies the CSI "snapshot_id" of a
-                    pre-existing snapshot on the underlying storage system. This field
-                    is immutable.
+                  description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system. This field is immutable.
                   type: string
                 volumeHandle:
-                  description: volumeHandle specifies the CSI "volume_id" of the volume
-                    from which a snapshot should be dynamically taken from. This field
-                    is immutable.
+                  description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
                   type: string
               type: object
             volumeSnapshotClassName:
-              description: name of the VolumeSnapshotClass to which this snapshot
-                belongs.
+              description: name of the VolumeSnapshotClass to which this snapshot belongs.
               type: string
             volumeSnapshotRef:
-              description: volumeSnapshotRef specifies the VolumeSnapshot object to
-                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
-                field must reference to this VolumeSnapshotContent's name for the
-                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
-                object, name and namespace of the VolumeSnapshot object MUST be provided
-                for binding to happen. This field is immutable after creation. Required.
+              description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
               properties:
                 apiVersion:
                   description: API version of the referent.
                   type: string
                 fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
+                  description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                   type: string
                 kind:
                   description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
@@ -182,8 +128,7 @@ spec:
                   description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                   type: string
                 resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                  description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -199,26 +144,14 @@ spec:
           description: status represents the current information of a snapshot.
           properties:
             creationTime:
-              description: creationTime is the timestamp when the point-in-time snapshot
-                is taken by the underlying storage system. In dynamic snapshot creation
-                case, this field will be filled in with the "creation_time" value
-                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
-                snapshot, this field will be filled with the "creation_time" value
-                returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                it. If not specified, it indicates the creation time is unknown. The
-                format of this field is a Unix nanoseconds time encoded as an int64.
-                On Unix, the command `date +%s%N` returns the current time in nanoseconds
-                since 1970-01-01 00:00:00 UTC.
+              description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in with the "creation_time" value returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
               format: int64
               type: integer
             error:
-              description: error is the latest observed error during snapshot creation,
-                if any.
+              description: error is the latest observed error during snapshot creation, if any.
               properties:
                 message:
-                  description: 'message is a string detailing the encountered error
-                    during snapshot creation if specified. NOTE: message may be logged,
-                    and it should not contain sensitive information.'
+                  description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
                   type: string
                 time:
                   description: time is the timestamp when the error was encountered.
@@ -226,32 +159,15 @@ spec:
                   type: string
               type: object
             readyToUse:
-              description: readyToUse indicates if a snapshot is ready to be used
-                to restore a volume. In dynamic snapshot creation case, this field
-                will be filled in with the "ready_to_use" value returned from CSI
-                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
-                field will be filled with the "ready_to_use" value returned from the
-                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
-                this field will be set to "True". If not specified, it means the readiness
-                of a snapshot is unknown.
+              description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in with the "ready_to_use" value returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
               type: boolean
             restoreSize:
-              description: restoreSize represents the complete size of the snapshot
-                in bytes. In dynamic snapshot creation case, this field will be filled
-                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
-                gRPC call. For a pre-existing snapshot, this field will be filled
-                with the "size_bytes" value returned from the CSI "ListSnapshots"
-                gRPC call if the driver supports it. When restoring a volume from
-                this snapshot, the size of the volume MUST NOT be smaller than the
-                restoreSize if it is specified, otherwise the restoration will fail.
-                If not specified, it indicates that the size is unknown.
+              description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in with the "size_bytes" value returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
               format: int64
               minimum: 0
               type: integer
             snapshotHandle:
-              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
-                the underlying storage system. If not specified, it indicates that
-                dynamic snapshot creation has either failed or it is still in progress.
+              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
               type: string
           type: object
       required:
@@ -290,89 +206,48 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: VolumeSnapshot is a user's request for either creating a point-in-time
-        snapshot of a persistent volume, or binding to a pre-existing snapshot.
+      description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
-          description: 'spec defines the desired characteristics of a snapshot requested
-            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
-            Required.'
+          description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
           properties:
             source:
-              description: source specifies where a snapshot will be created from.
-                This field is immutable after creation. Required.
+              description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
               properties:
                 persistentVolumeClaimName:
-                  description: persistentVolumeClaimName specifies the name of the
-                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
-                    object where the snapshot should be dynamically taken from. This
-                    field is immutable.
+                  description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object in the same namespace as the VolumeSnapshot object where the snapshot should be dynamically taken from. This field is immutable.
                   type: string
                 volumeSnapshotContentName:
-                  description: volumeSnapshotContentName specifies the name of a pre-existing
-                    VolumeSnapshotContent object. This field is immutable.
+                  description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object. This field is immutable.
                   type: string
               type: object
             volumeSnapshotClassName:
-              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
-                requested by the VolumeSnapshot. If not specified, the default snapshot
-                class will be used if one exists. If not specified, and there is no
-                default snapshot class, dynamic snapshot creation will fail. Empty
-                string is not allowed for this field. TODO(xiangqian): a webhook validation
-                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
+              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. If not specified, the default snapshot class will be used if one exists. If not specified, and there is no default snapshot class, dynamic snapshot creation will fail. Empty string is not allowed for this field. TODO(xiangqian): a webhook validation on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
               type: string
           required:
           - source
           type: object
         status:
-          description: 'status represents the current information of a snapshot. NOTE:
-            status can be modified by sources other than system controllers, and must
-            not be depended upon for accuracy. Controllers should only use information
-            from the VolumeSnapshotContent object after verifying that the binding
-            is accurate and complete.'
+          description: 'status represents the current information of a snapshot. NOTE: status can be modified by sources other than system controllers, and must not be depended upon for accuracy. Controllers should only use information from the VolumeSnapshotContent object after verifying that the binding is accurate and complete.'
           properties:
             boundVolumeSnapshotContentName:
-              description: 'boundVolumeSnapshotContentName represents the name of
-                the VolumeSnapshotContent object to which the VolumeSnapshot object
-                is bound. If not specified, it indicates that the VolumeSnapshot object
-                has not been successfully bound to a VolumeSnapshotContent object
-                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
-                mean binding       is valid. Controllers MUST always verify bidirectional
-                binding between       VolumeSnapshot and VolumeSnapshotContent to
-                avoid possible security issues.'
+              description: 'boundVolumeSnapshotContentName represents the name of the VolumeSnapshotContent object to which the VolumeSnapshot object is bound. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: Specified boundVolumeSnapshotContentName alone does not mean binding       is valid. Controllers MUST always verify bidirectional binding between       VolumeSnapshot and VolumeSnapshotContent to avoid possible security issues.'
               type: string
             creationTime:
-              description: creationTime is the timestamp when the point-in-time snapshot
-                is taken by the underlying storage system. In dynamic snapshot creation
-                case, this field will be filled in with the "creation_time" value
-                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
-                snapshot, this field will be filled with the "creation_time" value
-                returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                it. If not specified, it indicates that the creation time of the snapshot
-                is unknown.
+              description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in with the "creation_time" value returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates that the creation time of the snapshot is unknown.
               format: date-time
               type: string
             error:
-              description: error is the last observed error during snapshot creation,
-                if any. This field could be helpful to upper level controllers(i.e.,
-                application controller) to decide whether they should continue on
-                waiting for the snapshot to be created based on the type of error
-                reported.
+              description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported.
               properties:
                 message:
-                  description: 'message is a string detailing the encountered error
-                    during snapshot creation if specified. NOTE: message may be logged,
-                    and it should not contain sensitive information.'
+                  description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
                   type: string
                 time:
                   description: time is the timestamp when the error was encountered.
@@ -380,25 +255,10 @@ spec:
                   type: string
               type: object
             readyToUse:
-              description: readyToUse indicates if a snapshot is ready to be used
-                to restore a volume. In dynamic snapshot creation case, this field
-                will be filled in with the "ready_to_use" value returned from CSI
-                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
-                field will be filled with the "ready_to_use" value returned from the
-                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
-                this field will be set to "True". If not specified, it means the readiness
-                of a snapshot is unknown.
+              description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in with the "ready_to_use" value returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
               type: boolean
             restoreSize:
-              description: restoreSize represents the complete size of the snapshot
-                in bytes. In dynamic snapshot creation case, this field will be filled
-                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
-                gRPC call. For a pre-existing snapshot, this field will be filled
-                with the "size_bytes" value returned from the CSI "ListSnapshots"
-                gRPC call if the driver supports it. When restoring a volume from
-                this snapshot, the size of the volume MUST NOT be smaller than the
-                restoreSize if it is specified, otherwise the restoration will fail.
-                If not specified, it indicates that the size is unknown.
+              description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in with the "size_bytes" value returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
               type: string
           type: object
       required:
@@ -472,6 +332,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -497,6 +358,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -583,6 +451,14 @@ rules:
   - delete
   - update
   - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -634,6 +510,14 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -767,12 +651,12 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
-  name: snapshot-controller-leaderelection
+  name: ebs-snapshot-controller-leaderelection
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: snapshot-controller-leaderelection
+  name: ebs-snapshot-controller-leaderelection
 subjects:
 - kind: ServiceAccount
   name: ebs-snapshot-controller
@@ -876,10 +760,11 @@ spec:
       - args:
         - --csi-address=$(ADDRESS)
         - --v=5
+        - --handle-volume-inuse-error=false
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: quay.io/k8scsi/csi-resizer:v0.3.0
+        image: k8s.gcr.io/sig-storage/csi-resizer:v1.0.0
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -890,7 +775,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: quay.io/k8scsi/csi-snapshotter:v2.1.1
+        image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
         name: csi-snapshotter
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -914,7 +799,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: amazon/aws-ebs-csi-driver:latest
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.9.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -936,12 +821,12 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
-        - --enable-leader-election
-        - --leader-election-type=leases
+        - --leader-election=true
+        - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: quay.io/k8scsi/csi-provisioner:v1.5.0
+        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -950,24 +835,22 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --leader-election=true
-        - --leader-election-type=leases
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: quay.io/k8scsi/csi-attacher:v1.2.0
+        image: k8s.gcr.io/sig-storage/csi-attacher:v3.0.0
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: quay.io/k8scsi/livenessprobe:v1.1.0
+        image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
       nodeSelector:
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
@@ -1001,7 +884,7 @@ spec:
       - args:
         - --v=5
         - --leader-election=false
-        image: quay.io/k8scsi/snapshot-controller:v2.1.1
+        image: k8s.gcr.io/sig-storage/snapshot-controller:v3.0.3
         name: snapshot-controller
       serviceAccountName: ebs-snapshot-controller
 ---
@@ -1041,7 +924,7 @@ spec:
         env:
         - name: CSI_ENDPOINT
           value: unix:/csi/csi.sock
-        image: amazon/aws-ebs-csi-driver:latest
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.9.0
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -1074,7 +957,7 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
         lifecycle:
           preStop:
             exec:
@@ -1090,14 +973,13 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: quay.io/k8scsi/livenessprobe:v1.1.0
+        image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
           name: plugin-dir
       hostNetwork: true
       nodeSelector:
-        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
       tolerations:

--- a/modules/cluster/addons/aws-node-termination-handler.yaml
+++ b/modules/cluster/addons/aws-node-termination-handler.yaml
@@ -6,16 +6,16 @@ metadata:
   name: aws-node-termination-handler
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
-    helm.sh/chart: aws-node-termination-handler-0.10.0
+    helm.sh/chart: aws-node-termination-handler-0.13.3
     app.kubernetes.io/instance: aws-node-termination-handler
     k8s-app: aws-node-termination-handler
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.12.0"
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
   privileged: false
   hostIPC: false
-  hostNetwork: true
+  hostNetwork: true 
   hostPID: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false
@@ -40,10 +40,10 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
-    helm.sh/chart: aws-node-termination-handler-0.10.0
+    helm.sh/chart: aws-node-termination-handler-0.13.3
     app.kubernetes.io/instance: aws-node-termination-handler
     k8s-app: aws-node-termination-handler
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.12.0"
 ---
 # Source: aws-node-termination-handler/templates/clusterrole.yaml
 kind: ClusterRole
@@ -57,6 +57,7 @@ rules:
     - nodes
   verbs:
     - get
+    - list
     - patch
     - update
 - apiGroups:
@@ -91,10 +92,10 @@ metadata:
   name: aws-node-termination-handler-psp
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
-    helm.sh/chart: aws-node-termination-handler-0.10.0
+    helm.sh/chart: aws-node-termination-handler-0.13.3
     app.kubernetes.io/instance: aws-node-termination-handler
     k8s-app: aws-node-termination-handler
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.12.0"
 rules:
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
@@ -123,10 +124,10 @@ metadata:
   name: aws-node-termination-handler-psp
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
-    helm.sh/chart: aws-node-termination-handler-0.10.0
+    helm.sh/chart: aws-node-termination-handler-0.13.3
     app.kubernetes.io/instance: aws-node-termination-handler
     k8s-app: aws-node-termination-handler
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.12.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -144,10 +145,10 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
-    helm.sh/chart: aws-node-termination-handler-0.10.0
+    helm.sh/chart: aws-node-termination-handler-0.13.3
     app.kubernetes.io/instance: aws-node-termination-handler
     k8s-app: aws-node-termination-handler
-    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/version: "1.12.0"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -191,11 +192,11 @@ spec:
                   values:
                     - fargate
       serviceAccountName: aws-node-termination-handler
-      hostNetwork: true
+      hostNetwork: true 
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:
         - name: aws-node-termination-handler
-          image: amazon/aws-node-termination-handler:v1.8.0
+          image: public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.12.0
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
@@ -248,6 +249,8 @@ spec:
             value: "true"
           - name: ENABLE_SCHEDULED_EVENT_DRAINING
             value: "true"
+          - name: ENABLE_REBALANCE_MONITORING
+            value: "false"
           - name: METADATA_TRIES
             value: "3"
           - name: CORDON_ONLY
@@ -256,6 +259,8 @@ spec:
             value: "false"
           - name: JSON_LOGGING
             value: "false"
+          - name: LOG_LEVEL
+            value: "info"
           - name: WEBHOOK_PROXY
             value: ""
           - name: UPTIME_FROM_FILE

--- a/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/alpha/?ref=v0.6.0
+- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/alpha/?ref=release-0.9
 resources:
 - resources/crd_snapshotter.yaml
 patchesStrategicMerge:

--- a/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/alpha/?ref=release-0.9
+- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/alpha/?ref=v0.9.0
 resources:
 - resources/crd_snapshotter.yaml
 patchesStrategicMerge:


### PR DESCRIPTION
## Background

The terraform-aws-eks module uses several Docker images stored on Dockerhub but as the Dockerhub changed [its rate limit policy](https://www.docker.com/increase-rate-limits#:~:text=The%20rate%20limits%20of%20100,the%20six%20hour%20window%20elapses.), we have sometimes encountered the rate limit issue when we launch new containers.

This PR will change 

* the image repository for `aws-node-termination-handler` from Dockerhub to Amazon ECR
* the image repository for `aws-ebs-csi-driver` from Dockerhub to Google Container Registry.

## Changes

I executed `hack/generate_addons.sh` after I changed the following files 📝 

* https://github.com/cookpad/terraform-aws-eks/compare/master...update_docker_image_to_use_public_ecr?expand=1#diff-7fb6b414f1d357d10100fb9e82f44f50d55e6e853060b8c554921a366b1220a2R4
* https://github.com/cookpad/terraform-aws-eks/compare/master...update_docker_image_to_use_public_ecr?expand=1#diff-e0ac720aef782845ea3c04f4d3a6b31c8cc52755623c393d71a9040927b6a89aR20