### PR TITLE
[addons]  Use public NVIDIA image repository for nvidia-device-plugin

### DIFF
--- a/hack/generate_addons.sh
+++ b/hack/generate_addons.sh
@@ -19,7 +19,7 @@ kustomize_build() {
 
 helm_template eks aws-node-termination-handler 0.13.3
 helm_template autoscaler cluster-autoscaler 1.0.4 -chart
-helm_template nvdp nvidia-device-plugin 0.7.0
+helm_template nvdp nvidia-device-plugin 0.8.2
 
 curl -o $ADDONS_DIR/kustomize/overlays/metrics-server/resources/metrics-server.yaml -L https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
 kustomize_build metrics-server

--- a/modules/cluster/addons/nvidia-device-plugin.yaml
+++ b/modules/cluster/addons/nvidia-device-plugin.yaml
@@ -19,10 +19,10 @@ metadata:
   name: nvidia-device-plugin
   namespace: kube-system
   labels:
-    helm.sh/chart: nvidia-device-plugin-0.7.0
+    helm.sh/chart: nvidia-device-plugin-0.8.2
     app.kubernetes.io/name: nvidia-device-plugin
     app.kubernetes.io/instance: nvidia-device-plugin
-    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/version: "0.8.2"
 spec:
   selector:
     matchLabels:
@@ -48,7 +48,7 @@ spec:
       securityContext:
         {}
       containers:
-      - image: nvidia/k8s-device-plugin:v0.7.0
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.8.2
         imagePullPolicy: IfNotPresent
         name: nvidia-device-plugin-ctr
         args:
@@ -56,6 +56,7 @@ spec:
         - "--pass-device-specs=false"
         - "--fail-on-init-error=true"
         - "--device-list-strategy=envvar"
+        - "--nvidia-driver-root=/"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Background

To bypass the Dockerhub rate limits for the nvidia-device-plugin image, I'd like to use the public image registry which NVIDIA manages.

This PR also includes a [small change](https://github.com/cookpad/terraform-aws-eks/commit/38af30601b44f535da1be8f5a5dcc46902c2db9f) for `aws-ebs-csi-driver` which was generated by executing `hack/generate_addons.sh`.