### PR TITLE
[Addons] Use stable driver with v0.9.0

### DIFF
--- a/modules/cluster/addons/aws-ebs-csi-driver.yaml
+++ b/modules/cluster/addons/aws-ebs-csi-driver.yaml
@@ -826,7 +826,7 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
+        image: quay.io/k8scsi/csi-provisioner:v2.0.2
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -838,14 +838,14 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: k8s.gcr.io/sig-storage/csi-attacher:v3.0.0
+        image: quay.io/k8scsi/csi-attacher:v3.0.0
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
+        image: quay.io/k8scsi/livenessprobe:v2.1.0
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -957,7 +957,7 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
         lifecycle:
           preStop:
             exec:
@@ -973,7 +973,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
+        image: quay.io/k8scsi/livenessprobe:v2.1.0
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi

--- a/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/alpha/?ref=v0.9.0
+- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=v0.9.0
 resources:
 - resources/crd_snapshotter.yaml
 patchesStrategicMerge:

--- a/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
@@ -1,7 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=v0.9.0
+- github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/alpha/?ref=v0.9.0
+images:
+- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  newTag: v0.9.0
 resources:
 - resources/crd_snapshotter.yaml
 patchesStrategicMerge:


### PR DESCRIPTION
## Background

continue from https://github.com/cookpad/terraform-aws-eks/pull/191#discussion_r577925761

## Changes

* Override the image tag to use `v0.9.0` tag for aws-ebs-csi-driver image: https://github.com/cookpad/terraform-aws-eks/pull/196/files#diff-7fb6b414f1d357d10100fb9e82f44f50d55e6e853060b8c554921a366b1220a2R5-R7

Other changes are produced by `./hack/generate_addons.sh`.