### PR TITLE
[cluster/iam] Retire unnecessary AmazonEKSServicePolicy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
 module "iam" {
   source = "./modules/iam"
 
-  service_role_name = "eksServiceRole-${var.cluster_name}"
+  cluster_role_name = "eksClusterRole-${var.cluster_name}"
   node_role_name    = "EKSNode-${var.cluster_name}"
 }
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -2,13 +2,13 @@
   EKS control plane
 */
 
-data "aws_iam_role" "service_role" {
-  name = var.iam_config.service_role
+data "aws_iam_role" "cluster_role" {
+  name = var.iam_config.cluster_role
 }
 
 resource "aws_eks_cluster" "control_plane" {
   name     = var.name
-  role_arn = data.aws_iam_role.service_role.arn
+  role_arn = data.aws_iam_role.cluster_role.arn
   tags     = var.tags
 
   version = var.k8s_version

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -30,12 +30,12 @@ variable "vpc_config" {
 
 variable "iam_config" {
   type = object({
-    service_role = string
+    cluster_role = string
     node_role    = string
   })
 
   default = {
-    service_role = "eksServiceRole"
+    cluster_role = "eksClusterRole"
     node_role    = "EKSNode"
   }
 

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -4,7 +4,7 @@ This module configures the IAM roles needed to run an EKS cluster.
 
 ## Features
 
-* Configures a service role to be assumed by an EKS cluster.
+* Configures a cluster role to be assumed by an EKS cluster.
 * Configures a role and instance profile for use by EC2 worker nodes.
 
 This module outputs a config object that may be used to configure the cluster module's `iam_config` variable.

--- a/modules/iam/cluster_role.tf
+++ b/modules/iam/cluster_role.tf
@@ -1,5 +1,5 @@
-resource "aws_iam_role" "eks_service_role" {
-  name               = var.service_role_name
+resource "aws_iam_role" "eks_cluster_role" {
+  name               = var.cluster_role_name
   assume_role_policy = data.aws_iam_policy_document.eks_assume_role_policy.json
 }
 
@@ -14,12 +14,7 @@ data "aws_iam_policy_document" "eks_assume_role_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "eks_service_policy" {
-  role       = aws_iam_role.eks_service_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
-}
-
 resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
-  role       = aws_iam_role.eks_service_role.name
+  role       = aws_iam_role.eks_cluster_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
 }

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,6 +1,6 @@
 output "config" {
   value = {
-    service_role = aws_iam_role.eks_service_role.name
+    cluster_role = aws_iam_role.eks_cluster_role.name
     node_role    = aws_iam_role.eks_node.name
   }
   depends_on = [

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -1,6 +1,6 @@
-variable "service_role_name" {
+variable "cluster_role_name" {
   type    = string
-  default = "eksServiceRole"
+  default = "eksClusterRole"
 }
 
 variable "node_role_name" {


### PR DESCRIPTION
## Background

According to the [AWS EKS document](https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html,),

> Prior to April 16, 2020, AmazonEKSServicePolicy was also required and the suggested name was eksServiceRole. With the AWSServiceRoleForAmazonEKS service-linked role, that policy is no longer required for clusters created on or after April 16, 2020.

Now, removing `AmazonEKSServicePolicy` from the attached policy and renaming the IAM role used by EKS control plane from service_role to cluster_role makes sense to catch up with the changes in the official document.

## References

* https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
* https://docs.aws.amazon.com/eks/latest/userguide/using-service-linked-roles-eks.html