### PR TITLE
Include `depends_on` in iam module usage docs

### DIFF
--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -21,5 +21,8 @@ module "cluster" {
   name       = "sal-9000"
   iam_config = module.iam.config
   ...
+  depends_on = [
+    module.iam,
+  ]
 }
 ```


### PR DESCRIPTION
I believe it is necessary to specify `depends_on` when using the iam module alongside the cluster module, because internally the cluster module uses a `data` resource to fetch the roles.

Example `plan` output:

> NoSuchEntity: The role with name EKSNode cannot be found

I believe that the `data` source in question here is [this one](https://github.com/cookpad/terraform-aws-eks/blob/b09b004b3f683b60949e23189be11acf3ddf22ac/modules/cluster/main.tf#L61).

An example failed plan is [here](https://github.com/cookpad/global-aws/pull/435#issuecomment-790762218) - which was generated from commit `144fd90d` on that PR. Its worth noting that `node_role` and `service_role` vars are specified on the `iam` module resource - which isn't true of the example in these docs. Could be related?

### Notes

 `iam.config.node_role` clearly depends on the resource being created [here](https://github.com/cookpad/terraform-aws-eks/blob/b09b004b3f683b60949e23189be11acf3ddf22ac/modules/iam/outputs.tf#L4), but this isn't made obvious to the cluster module [here](https://github.com/cookpad/terraform-aws-eks/blob/b09b004b3f683b60949e23189be11acf3ddf22ac/modules/cluster/main.tf#L61) which only views `iam_config` as a var.