### PR TITLE
[Cluster module] Improve dependency detection (DAG) using ARNs of node/service IAM roles instead of name

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,6 +12,8 @@
 [#203](https://github.com/cookpad/terraform-aws-eks/pull/203) removes `failure-domain.beta.kubernetes.io/zone` label which is deprecated in favour of `topology.kubernetes.io/zone`. Use the new label in any affinity specs.
 
 
+[#202](https://github.com/cookpad/terraform-aws-eks/pull/202) deprecates `node_role` and `service_role` in the `iam_config` variable for the cluster module. Instead, you need to specify `node_role_arn` and `service_role_arn` via `iam_config`.
+
 ## 1.17 -> 1.18
 
 [#170](https://github.com/cookpad/terraform-aws-eks/pull/170) renames the cluster-module and root module outputs

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -2,13 +2,9 @@
   EKS control plane
 */
 
-data "aws_iam_role" "service_role" {
-  name = var.iam_config.service_role
-}
-
 resource "aws_eks_cluster" "control_plane" {
   name     = var.name
-  role_arn = data.aws_iam_role.service_role.arn
+  role_arn = var.iam_config.service_role_arn
   tags     = var.tags
 
   version = var.k8s_version
@@ -58,15 +54,11 @@ resource "aws_cloudwatch_log_group" "control_plane" {
   Allow nodes to join the cluster
 */
 
-data "aws_iam_role" "node_role" {
-  name = var.iam_config.node_role
-}
-
 locals {
   aws_auth_role_map = concat(
     [
       {
-        rolearn  = data.aws_iam_role.node_role.arn
+        rolearn  = var.iam_config.node_role_arn
         username = "system:node:{{EC2PrivateDNSName}}"
         groups   = ["system:bootstrappers", "system:nodes"]
       },

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -6,7 +6,7 @@ locals {
     vpc_id                = var.vpc_config.vpc_id
     private_subnet_ids    = var.vpc_config.private_subnet_ids
     node_security_group   = aws_eks_cluster.control_plane.vpc_config.0.cluster_security_group_id
-    node_instance_profile = var.iam_config.node_role
+    node_instance_profile = regex("^arn:aws:iam::\\d+:role/*.*/(.+)?", var.iam_config.node_role_arn)[0]
     tags                  = var.tags
     dns_cluster_ip        = local.dns_cluster_ip
     aws_ebs_csi_driver    = var.aws_ebs_csi_driver

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -32,13 +32,11 @@ variable "iam_config" {
   type = object({
     service_role_arn = string
     node_role_arn    = string
-    node_role        = string
   })
 
   default = {
     service_role_arn = ""
     node_role_arn    = ""
-    node_role        = "EKSNode"
   }
 
   description = "The ARN of IAM roles used by the cluster, If you use the included IAM module you can provide it's config output variable."

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -30,16 +30,18 @@ variable "vpc_config" {
 
 variable "iam_config" {
   type = object({
-    service_role = string
-    node_role    = string
+    service_role_arn = string
+    node_role_arn    = string
+    node_role        = string
   })
 
   default = {
-    service_role = "eksServiceRole"
-    node_role    = "EKSNode"
+    service_role_arn = ""
+    node_role_arn    = ""
+    node_role        = "EKSNode"
   }
 
-  description = "The IAM roles used by the cluster, If you use the included IAM module you can provide it's config output variable."
+  description = "The ARN of IAM roles used by the cluster, If you use the included IAM module you can provide it's config output variable."
 }
 
 variable "cluster_autoscaler_iam_permissions_boundary" {

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,8 +1,10 @@
 output "config" {
   value = {
-    service_role = aws_iam_role.eks_service_role.name
-    node_role    = aws_iam_role.eks_node.name
+    service_role_arn = aws_iam_role.eks_service_role.arn
+    node_role        = aws_iam_role.eks_node.name
+    node_role_arn    = aws_iam_role.eks_node.arn
   }
+
   depends_on = [
     aws_iam_role_policy_attachment.eks_worker_node,
     aws_iam_role_policy_attachment.eks_cni,

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,7 +1,6 @@
 output "config" {
   value = {
     service_role_arn = aws_iam_role.eks_service_role.arn
-    node_role        = aws_iam_role.eks_node.name
     node_role_arn    = aws_iam_role.eks_node.arn
   }
 


### PR DESCRIPTION
# Background

dup: https://github.com/cookpad/terraform-aws-eks/pull/201.

The cluster module is intended to resolve dependencies between the cluster module and [IAM roles passed via a variable](https://github.com/cookpad/terraform-aws-eks/blob/b09b004b3f683b60949e23189be11acf3ddf22ac/modules/cluster/variables.tf#L31-L42).

However, there are possibilities that the cluster module cannot detect the dependencies even we pass new IAM roles passed via a variable.

* https://github.com/cookpad/terraform-aws-eks/pull/201#issue-585541413
* https://github.com/cookpad/terraform-aws-eks/pull/201#issuecomment-793647591

I think this is because the cluster module uses `data` sources to retrieve IAM roles with `name`. If we can pass ARNs of IAM role and eliminate the data blocks for IAM role retrieval, the dependency issue will be solved (obvious for Terraform) and we don't have to use `depends_on` for inter-module dependency declaration.

# Goal

* Pass ARNs of IAM role for both node and control plane instead of names of the IAM role
