### PR TITLE
udpate aws-k8s-cni to 1.7.10

### DIFF
--- a/modules/cluster/addons/aws-k8s-cni.yaml
+++ b/modules/cluster/addons/aws-k8s-cni.yaml
@@ -153,7 +153,7 @@
               "fieldPath": "spec.nodeName"
         - "name": "WARM_ENI_TARGET"
           "value": "1"
-        "image": "602401143452.dkr.ecr.${aws_region}.amazonaws.com/amazon-k8s-cni:v1.7.5"
+        "image": "602401143452.dkr.ecr.${aws_region}.amazonaws.com/amazon-k8s-cni:v1.7.10"
         "imagePullPolicy": "Always"
         "livenessProbe":
           "exec":
@@ -196,7 +196,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.5"
+        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.10"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":


### PR DESCRIPTION
Update amazon-k8s-cni to 1.7.10.
This was missed in the 1.18 release so we should release a patch to previous releases as well as targetting 1.19.
Could help bug between `aws-node` / `kube-proxy` startup when a node comes online 
example from @dan-slinky-ckpd 

```
{"level":"info","ts":"2021-04-14T14:33:42.862Z","caller":"entrypoint.sh","msg":"Install CNI binary.."}
{"level":"info","ts":"2021-04-14T14:33:42.877Z","caller":"entrypoint.sh","msg":"Starting IPAM daemon in the background ... "}
{"level":"info","ts":"2021-04-14T14:33:42.879Z","caller":"entrypoint.sh","msg":"Checking for IPAM connectivity ... "}
ERROR: logging before flag.Parse: E0414 14:34:12.902426      10 memcache.go:138] couldn't get current server API group list; will keep using cached value. (Get https://172.20.0.1:443/api?timeout=32s: dial tcp 172.20.0.1:443: i/o timeout)
```
but `kube-proxy` didn’t have iptables configured until after
```
I0414 14:34:13.547814       7 service.go:379] Adding new service port "default/kubernetes:https" at 172.20.0.1:443/TCP
```