### PR TITLE
bind kube-proxy to 127.0.0.1 when IPV6 is not required

### DIFF
--- a/modules/cluster/addons/kube-proxy.yaml
+++ b/modules/cluster/addons/kube-proxy.yaml
@@ -9,7 +9,8 @@ metadata:
 data:
   config: |-
     apiVersion: kubeproxy.config.k8s.io/v1alpha1
-    bindAddress: 0.0.0.0
+    # Advice from https://github.com/aws/amazon-vpc-cni-k8s/issues/1078#issuecomment-804655593
+    bindAddress: 127.0.0.1
     clientConnection:
       acceptContentTypes: ""
       burst: 10


### PR DESCRIPTION
Following the advice from https://github.com/aws/amazon-vpc-cni-k8s/issues/1078#issuecomment-804655593
This fix should stop us hitting the bug around unstable aws-node startup. 
I've made the bindAddress configurable via ipv4/6 usage as binding to 127.0.0.1 will not work for ipv6