### PR TITLE
Fix aws-ebs-csi driver issues

### DIFF
--- a/modules/cluster/addons/aws-ebs-csi-driver.yaml
+++ b/modules/cluster/addons/aws-ebs-csi-driver.yaml
@@ -1749,6 +1749,8 @@ spec:
       - effect: NoExecute
         operator: Exists
         tolerationSeconds: 300
+      - effect: NoSchedule
+        operator: Exists
       volumes:
       - hostPath:
           path: /var/lib/kubelet

--- a/modules/cluster/addons/aws-ebs-csi-driver.yaml
+++ b/modules/cluster/addons/aws-ebs-csi-driver.yaml
@@ -999,6 +999,8 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: ${iam_role_arn}
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
   name: ebs-snapshot-controller

--- a/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/daemonset_tolerations.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/daemonset_tolerations.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ebs-csi-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 300
+      - effect: NoSchedule
+        operator: Exists

--- a/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/eks_iam_for_sa.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/eks_iam_for_sa.yaml
@@ -5,3 +5,11 @@ metadata:
   namespace: kube-system
   annotations:
     eks.amazonaws.com/role-arn: ${iam_role_arn}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-snapshot-controller
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: ${iam_role_arn}

--- a/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
+++ b/modules/cluster/addons/kustomize/overlays/aws-ebs-csi-driver/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - resources/crd_snapshotter.yaml
 patchesStrategicMerge:
 - eks_iam_for_sa.yaml
+- daemonset_tolerations.yaml


### PR DESCRIPTION
* Add the IAM role annotation back for the ebs-snapshot-controller ServiceAccount (removed in #213)
* Add NoSchedule toleration to ebs-csi-node DaemonSet so that it is scheduled to all nodes