### PR TITLE
Increase memory request and limit for cluster-autoscaler addon, add p2.large to gpu_node_group example

### DIFF
--- a/examples/cluster/gpu_node_group/main.tf
+++ b/examples/cluster/gpu_node_group/main.tf
@@ -15,7 +15,7 @@ module "gpu_nodes" {
   gpu             = true
   instance_family = "gpu"
   instance_size   = "2xlarge"
-  instance_types  = ["p3.2xlarge"]
+  instance_types  = ["p2.xlarge", "p3.2xlarge"]
   zone_awareness  = false
   min_size        = 1
 

--- a/modules/cluster/addons/cluster-autoscaler.yaml
+++ b/modules/cluster/addons/cluster-autoscaler.yaml
@@ -351,10 +351,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 500Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 500Mi
       serviceAccountName: cluster-autoscaler
       tolerations:
         - key: CriticalAddonsOnly

--- a/modules/cluster/addons/helm/cluster-autoscaler.yaml
+++ b/modules/cluster/addons/helm/cluster-autoscaler.yaml
@@ -27,7 +27,7 @@ nameOverride: aws-cluster-autoscaler
 resources:
   limits:
     cpu: 100m
-    memory: 300Mi
+    memory: 500Mi
   requests:
     cpu: 100m
-    memory: 300Mi
+    memory: 500Mi


### PR DESCRIPTION
Contributes #210

- increase memory/limit for cluster-autoscaler
- add p2.xlarge to example asg_node_group module example `gpu_node_group` 

Investigating CI failures on #225 I had a look at the test cluster, and the cluster-autoscaler pod was repeatedly restarting due to OOM errors.
The particular test failure was that the test workload pods wouldn't start in `validateClusterAutoscaler` (if the cluster-autoscaler pod was OOM then it would not be able to trigger scale-up).
