### PR TITLE
Deprecate --delete-local-data

### DIFF
--- a/hack/roll_nodes.sh
+++ b/hack/roll_nodes.sh
@@ -72,7 +72,7 @@ done
 for NODE in $NODES_TO_ROLL
 do
   detach $NODE
-  kubectl drain --delete-local-data --ignore-daemonsets $NODE
+  kubectl drain --delete-empty-dir --ignore-daemonsets $NODE
   aws $AWS_EXTRA_ARGS ec2 terminate-instances --instance-ids $(instance_id $NODE)
   wait_for_pods
 done


### PR DESCRIPTION
When running `hack/roll_nodes.sh`, I got this warning message:

`Flag --delete-local-data has been deprecated, This option is deprecated
and will be deleted. Use --delete-emptydir-data.`

This change fixes that by using `--delete-emptydir-data` instead.

Reference: https://github.com/kubernetes/kubernetes/pull/95076