### PR TITLE
Simplify 1.19 upgrade notes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,10 +8,10 @@
 
 ## 1.18 -> 1.19
 
-[#195](https://github.com/cookpad/terraform-aws-eks/pull/195) upgrades `aws-alb-ingress-controller` to [`aws-load-balancer-controller`](https://github.com/cookpad/terraform-aws-eks/pull/195) (the project was renamed with the v2 release). Check the [upgrade guide for this project](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.0/guide/upgrade/migrate_v1_v2/) if you are using `aws-alb-ingress-controller`, you may need to update your ingress definitions.
 [#204](https://github.com/cookpad/terraform-aws-eks/pull/204) EKS no longer adds `kubernetes.io/cluster/<cluster-name>` to subnets. They will not be removed on upgrading to 1.19, but we recommend to codify the tags yourself for completeness if you are not using the vpc module and you want to keep using auto-discovery with eks-load-balancer-controller.
 [#203](https://github.com/cookpad/terraform-aws-eks/pull/203) removes `failure-domain.beta.kubernetes.io/zone` label which is deprecated in favour of `topology.kubernetes.io/zone`. Use the new label in any affinity specs.
 [#195](https://github.com/cookpad/terraform-aws-eks/pull/295) / [#225](https://github.com/cookpad/terraform-aws-eks/pull/225) removes the `aws-alb-ingress-controller` addon. The upgrade will not delete the addon from the cluster but takes it out of control of the module, so users should manage the package themselves through another mechanism.
+
 ## 1.18.3+
 
 This release updated ebs-csi-driver, 


### PR DESCRIPTION
In this release we upgrade to aws-load-balancer-controller, but then
remove it.

As both actions happen within a single release, it's less confusing to
just say we removed it.