### PR TITLE
Prepare repository for default branch rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - '*.md'
       - 'docs/**'
     branches:
-      - master
+      - main
       - release-*
   schedule:
     - cron: "0 11 * * 1-5"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "eks" {
 For more advanced uses, we recommend that you construct and configure
 your clusters using the submodules.
 
-[see example](https://github.com/cookpad/terraform-aws-eks/blob/master/examples/cluster/main.tf)
+[see example](https://github.com/cookpad/terraform-aws-eks/blob/main/examples/cluster/main.tf)
 
 This allows for much more flexibility, in order to for example:
 
@@ -65,7 +65,7 @@ provider "aws" {
 }
 ```
 
-[see an example role here](https://github.com/cookpad/terraform-aws-eks/blob/master/examples/iam_permissions/main.tf)
+[see an example role here](https://github.com/cookpad/terraform-aws-eks/blob/main/examples/iam_permissions/main.tf)
 
 Without this you may encounter difficulties applying kubernetes manifests to
 the cluster.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ or otherwise break a cluster.
 
 # Branching
 
-`master` is the main development branch for this module. Changes to the module
+`main` is the main development branch for this module. Changes to the module
 and updates should be merged here via pull request. Master should be maintained
 with the most up-to date working configuration.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,7 +38,7 @@ or otherwise break a cluster.
 # Branching
 
 `main` is the main development branch for this module. Changes to the module
-and updates should be merged here via pull request. Master should be maintained
+and updates should be merged here via pull request. `main` should be maintained
 with the most up-to date working configuration.
 
 Once a particular version is ready for pre-production testing a branch named 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -62,7 +62,7 @@ and nodes. To continue to use these (and avoid recreating the cluster) set
 Update terraform state:
 
 ```shell
-wget https://raw.githubusercontent.com/cookpad/terraform-aws-eks/master/hack/update_1_15.sh
+wget https://raw.githubusercontent.com/cookpad/terraform-aws-eks/main/hack/update_1_15.sh
 chmod +x update_1_15.sh
 ./update_1_15.sh example-cluster-module
 ```


### PR DESCRIPTION
Reference:
https://github.blog/changelog/2021-01-19-support-for-renaming-an-existing-branch/