### PR TITLE
Switch kubectl to exec credential provider

### DIFF
--- a/modules/cluster/kubectl/kubeconfig.yaml
+++ b/modules/cluster/kubectl/kubeconfig.yaml
@@ -8,7 +8,18 @@ clusters:
 users:
 - name: ${cluster_name}
   user:
-    token: ${token}
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: aws
+      args:
+        - "eks"
+        - "get-token"
+        - "--cluster-name"
+        - "${cluster_name}"
+%{ if role_arn != "" }
+        - "--role-arn"
+        - "${role_arn}"
+%{ endif }
 contexts:
 - name: ${cluster_name}
   context:

--- a/modules/cluster/kubectl/variables.tf
+++ b/modules/cluster/kubectl/variables.tf
@@ -29,3 +29,9 @@ variable "replace" {
   description = "Fall back to replace --force if apply fails"
   default     = false
 }
+
+variable "role_arn" {
+  type        = string
+  description = "IAM role to assume when authenticating with the EKS cluster, defaults to role assumed by aws provider config"
+  default     = ""
+}


### PR DESCRIPTION
Passing the token from aws_eks_cluster_auth data source meant
that the token is generated at plan time - as the tokens
are only valid for 15 minutes this can cause issues when there
is some time elapsed between plan and apply, or if the apply takes
more than 15 minutes e.g. when provisioning a new cluster.

See also this documentation: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#exec-plugins