### PR TITLE
fix hack/roll_nodes

### DIFF
--- a/hack/roll_nodes.sh
+++ b/hack/roll_nodes.sh
@@ -72,7 +72,7 @@ done
 for NODE in $NODES_TO_ROLL
 do
   detach $NODE
-  kubectl drain --delete-empty-dir --ignore-daemonsets $NODE
+  kubectl drain --delete-emptydir-data --ignore-daemonsets $NODE
   aws $AWS_EXTRA_ARGS ec2 terminate-instances --instance-ids $(instance_id $NODE)
   wait_for_pods
 done


### PR DESCRIPTION
Follow-up to f352e8a3246f5d87fc49a11cdcc06d0dc05d3984
`kubectl drain` accepts argument `--delete-emptydir-data` not `--delete-empty-dir`