### PR TITLE
Fix kube-bench checks on Bottlerocket OS nodes

### DIFF
--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -331,7 +331,7 @@ func validateStorage(t *testing.T, kubeconfig string) {
 	workload := fmt.Sprintf(EXAMPLE_STORAGE_WORKLOAD, namespace, namespace, namespace)
 	defer k8s.DeleteNamespace(t, kubectlOptions, namespace)
 	k8s.KubectlApplyFromString(t, kubectlOptions, workload)
-	WaitUntilPodsSucceeded(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=storage-test-workload"}, 1, 30, 10*time.Second)
+	WaitUntilPodsSucceeded(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=storage-test-workload"}, 1, 60, 10*time.Second)
 }
 
 const EXAMPLE_STORAGE_WORKLOAD = `---
@@ -386,7 +386,7 @@ func validateKubeBenchExpectedFails(t *testing.T, kubeconfig string, expectedFai
 	kubectlOptions := k8s.NewKubectlOptions("", kubeconfig, "kube-bench")
 	defer k8s.DeleteNamespace(t, kubectlOptions, "kube-bench")
 	k8s.KubectlApplyFromString(t, kubectlOptions, KUBEBENCH_MANIFEST)
-	WaitUntilPodsSucceeded(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=kube-bench"}, 1, 30, 5*time.Second)
+	WaitUntilPodsSucceeded(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=kube-bench"}, 1, 60, 5*time.Second)
 	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "logs", "-l", "app=kube-bench")
 	require.NoError(t, err)
 	resultWrapper := KubeBenchResult{}


### PR DESCRIPTION
## Background

closes https://github.com/cookpad/terraform-aws-eks/issues/186.

Because kube-bench v0.6.3 fixes failures on Bottlerocket nodes, we can fix kube-bench failures if we upgrade the image version. 


See https://github.com/aquasecurity/kube-bench/discussions/90 for more details.

## Goal

* Upgrade kube-bench image to v0.6.5 

## Reference

* https://github.com/aquasecurity/kube-bench/discussions/900
* https://github.com/aquasecurity/kube-bench/issues/887
* [Docker image for kube-bench v0.6.5](https://hub.docker.com/layers/aquasec/kube-bench/v0.6.5/images/sha256-efaf4ba0d1c98d798c15baff83d0c15d56b4253d7e778a734a6eccc9c555626e?context=explore)