### PR TITLE
upgrade coredns to 1.8.3

### DIFF
--- a/modules/cluster/addons/coredns.yaml
+++ b/modules/cluster/addons/coredns.yaml
@@ -32,6 +32,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -144,7 +151,7 @@ spec:
         operator: "Exists"
       containers:
       - name: coredns
-        image: 602401143452.dkr.ecr.${aws_region}.amazonaws.com/eks/coredns:v1.8.0-eksbuild.1
+        image: 602401143452.dkr.ecr.${aws_region}.amazonaws.com/eks/coredns:v1.8.3-eksbuild.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Closes #211
Contributes #246 

Follows the recommended upgrade path to 1.8.3 https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
1.8.3 is the recommended version for k8s 1.20 