### PR TITLE
Add necessary variable and dependencies for minimum possible config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,9 @@ module "iam" {
 }
 
 module "cluster" {
+  depends_on = [
+    module.iam,
+  ]
   source = "./modules/cluster"
 
   name = var.cluster_name
@@ -29,6 +32,9 @@ module "cluster" {
 }
 
 module "node_group" {
+  depends_on = [
+    module.iam,
+  ]
   source = "./modules/asg_node_group"
 
   cluster_config = module.cluster.config

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_name" {
   description = "A name for the EKS cluster, and the resources it depends on"
 }
 
+variable "cluster_names" {
+  type        = list(string)
+  default     = []
+  description = "Names of the EKS clusters deployed in the VPC."
+}
+
 variable "cidr_block" {
   type        = string
   description = "The CIDR block for the VPC that EKS will run in"
@@ -28,4 +34,3 @@ variable "envelope_encryption_enabled" {
   default     = true
   description = "Should Cluster Envelope Encryption be enabled, if changed after provisioning - forces the cluster to be recreated"
 }
-


### PR DESCRIPTION
Closes #251. This PR adds a necessary variable for the VPC module and fixes a dependency issue where resources that need IAM roles would try to be created before the roles they require.

Also -- should I bump the patch or minor version here?

