### PR TITLE
[Cluster module] Improve dependency detection (DAG) using ARNs of node/service IAM roles instead of name

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,8 @@
 ## 1.19 -> 1.20
 [247](https://github.com/cookpad/terraform-aws-eks/pull/247) 💥 Breaking Change. The `k8s_version` variable has been removed. Use the correct version of the module for the k8s version you want to use.
 
+[#257](https://github.com/cookpad/terraform-aws-eks/pull/257) 💥 Breaking Change. This change deprecates `node_role` and `service_role` in the `iam_config` variable for the cluster module. Instead, you need to specify `node_role_arn` and `service_role_arn` via `iam_config`.
+
 ## 1.18 -> 1.19
 
 [#204](https://github.com/cookpad/terraform-aws-eks/pull/204) EKS no longer adds `kubernetes.io/cluster/<cluster-name>` to subnets. They will not be removed on upgrading to 1.19, but we recommend to codify the tags yourself for completeness if you are not using the vpc module and you want to keep using auto-discovery with eks-load-balancer-controller.

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -2,16 +2,13 @@
   EKS control plane
 */
 
-data "aws_iam_role" "service_role" {
-  name = var.iam_config.service_role
-}
 locals {
   k8s_version = "1.19"
 }
 
 resource "aws_eks_cluster" "control_plane" {
   name     = var.name
-  role_arn = data.aws_iam_role.service_role.arn
+  role_arn = var.iam_config.service_role_arn
   tags     = var.tags
 
   version = local.k8s_version
@@ -60,15 +57,11 @@ resource "aws_cloudwatch_log_group" "control_plane" {
   Allow nodes to join the cluster
 */
 
-data "aws_iam_role" "node_role" {
-  name = var.iam_config.node_role
-}
-
 locals {
   aws_auth_role_map = concat(
     [
       {
-        rolearn  = data.aws_iam_role.node_role.arn
+        rolearn  = var.iam_config.node_role_arn
         username = "system:node:{{EC2PrivateDNSName}}"
         groups   = ["system:bootstrappers", "system:nodes"]
       },

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -6,6 +6,8 @@ locals {
     vpc_id                = var.vpc_config.vpc_id
     private_subnet_ids    = var.vpc_config.private_subnet_ids
     node_security_group   = aws_eks_cluster.control_plane.vpc_config.0.cluster_security_group_id
+    # this regular expression comes from the following link to retrieve role names
+    # https://github.com/cookpad/terraform-aws-eks/pull/257/commits/99fae9b5dab1b2b2d2b1085a479f57d45e62e0ce
     node_instance_profile = regex("^arn:aws:iam::\\d+:role/*.*/(.+)?", var.iam_config.node_role_arn)[0]
     tags                  = var.tags
     dns_cluster_ip        = local.dns_cluster_ip

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -6,7 +6,7 @@ locals {
     vpc_id                = var.vpc_config.vpc_id
     private_subnet_ids    = var.vpc_config.private_subnet_ids
     node_security_group   = aws_eks_cluster.control_plane.vpc_config.0.cluster_security_group_id
-    node_instance_profile = var.iam_config.node_role
+    node_instance_profile = regex("^arn:aws:iam::\\d+:role/*.*/(.+)?", var.iam_config.node_role_arn)[0]
     tags                  = var.tags
     dns_cluster_ip        = local.dns_cluster_ip
     aws_ebs_csi_driver    = var.aws_ebs_csi_driver

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -1,11 +1,11 @@
 locals {
   config = {
-    name                  = aws_eks_cluster.control_plane.name
-    endpoint              = aws_eks_cluster.control_plane.endpoint
-    ca_data               = aws_eks_cluster.control_plane.certificate_authority[0].data
-    vpc_id                = var.vpc_config.vpc_id
-    private_subnet_ids    = var.vpc_config.private_subnet_ids
-    node_security_group   = aws_eks_cluster.control_plane.vpc_config.0.cluster_security_group_id
+    name                = aws_eks_cluster.control_plane.name
+    endpoint            = aws_eks_cluster.control_plane.endpoint
+    ca_data             = aws_eks_cluster.control_plane.certificate_authority[0].data
+    vpc_id              = var.vpc_config.vpc_id
+    private_subnet_ids  = var.vpc_config.private_subnet_ids
+    node_security_group = aws_eks_cluster.control_plane.vpc_config.0.cluster_security_group_id
     # this regular expression comes from the following link to retrieve role names
     # https://github.com/cookpad/terraform-aws-eks/pull/257/commits/99fae9b5dab1b2b2d2b1085a479f57d45e62e0ce
     node_instance_profile = regex("^arn:aws:iam::\\d+:role/*.*/(.+)?", var.iam_config.node_role_arn)[0]

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -32,13 +32,13 @@ variable "vpc_config" {
 
 variable "iam_config" {
   type = object({
-    service_role = string
-    node_role    = string
+    service_role_arn = string
+    node_role_arn    = string
   })
 
   default = {
-    service_role = "eksServiceRole"
-    node_role    = "EKSNode"
+    service_role_arn = ""
+    node_role_arn    = ""
   }
 
   description = "The IAM roles used by the cluster, If you use the included IAM module you can provide it's config output variable."

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,7 +1,7 @@
 output "config" {
   value = {
-    service_role = aws_iam_role.eks_service_role.name
-    node_role    = aws_iam_role.eks_node.name
+    service_role_arn = aws_iam_role.eks_service_role.arn
+    node_role_arn    = aws_iam_role.eks_node.arn
   }
   depends_on = [
     aws_iam_role_policy_attachment.eks_worker_node,


### PR DESCRIPTION
reported by https://github.com/cookpad/terraform-aws-eks/issues/251

# Background

When we use this module based on the `README.md`, we could deploy a EKS cluster out-of-box.

```tf
module "eks" {
  source = "cookpad/eks/aws"
  version = "~> 1.16"

  cluster_name       = "hal-9000"
  cidr_block         = "10.4.0.0/16"
  availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
}
```

However, the latest version of this module causes errors and we cannot deploy a new EKS cluster as the README.md is describing.

## Error 1

**updated**: see the comment https://github.com/cookpad/terraform-aws-eks/pull/257#issuecomment-952658139. 

```
Error: Reference to undeclared input variable

  on .terraform/modules/eks/main.tf line 7, in module "vpc":
   7:   cluster_names      = var.cluster_names

An input variable with the name "cluster_names" has not been declared. Did you
mean "cluster_name"?
```

## Error 2

```
Error: error reading IAM Role (eksServiceRole-noah-berman-lab-cluster): NoSuchEntity: The role with name eksServiceRole-noah-berman-lab-cluster cannot be found.
	status code: 404, request id: foo-1

  on ../../../../terraform-aws-eks/modules/cluster/main.tf line 5, in data "aws_iam_role" "service_role":
   5: data "aws_iam_role" "service_role" {



Error: error reading IAM Role (EKSNode-noah-berman-lab-cluster): NoSuchEntity: The role with name EKSNode-noah-berman-lab-cluster cannot be found.
	status code: 404, request id: foo-2

  on ../../../../terraform-aws-eks/modules/cluster/main.tf line 64, in data "aws_iam_role" "node_role":
  64: data "aws_iam_role" "node_role" {
```


# Goal

* Fix the above errors.