### PR TITLE
fix: add cluster_names variable to the root module

### DIFF
--- a/examples/cluster/environment/main.tf
+++ b/examples/cluster/environment/main.tf
@@ -10,6 +10,7 @@ module "vpc" {
   name               = var.vpc_name
   cidr_block         = var.cidr_block
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1d"]
+  cluster_names      = var.cluster_names
 }
 
 module "iam" {

--- a/examples/cluster/environment/variables.tf
+++ b/examples/cluster/environment/variables.tf
@@ -7,3 +7,9 @@ variable "cidr_block" {
   type    = string
   default = "10.0.0.0/18"
 }
+
+variable "cluster_names" {
+  description = "Names of the EKS clusters deployed in this VPC."
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "cluster_name" {
   description = "A name for the EKS cluster, and the resources it depends on"
 }
 
+variable "cluster_names" {
+  type        = list(string)
+  description = ""
+}
+
 variable "cidr_block" {
   type        = string
   description = "The CIDR block for the VPC that EKS will run in"


### PR DESCRIPTION
from https://github.com/cookpad/terraform-aws-eks/issues/251

## Background

When we use this module based on the `README.md`, we could deploy a EKS cluster out-of-box.

```tf
module "eks" {
  source = "cookpad/eks/aws"
  version = "~> 1.16"

  cluster_name       = "hal-9000"
  cidr_block         = "10.4.0.0/16"
  availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
}
```

However, the latest version of this module causes the following error and we cannot deploy a new EKS cluster as the README.md is describing.


```
Error: Reference to undeclared input variable

  on .terraform/modules/eks/main.tf line 7, in module "vpc":
   7:   cluster_names      = var.cluster_names

An input variable with the name "cluster_names" has not been declared. Did you
mean "cluster_name"?
```

This is because https://github.com/cookpad/terraform-aws-eks/pull/204/files#diff-c44b22e5b95f6bb285aca81ba7dca1105bf26c8d092646314b6af58341e8b480R13 introduces the cluster_names variable for vpc module. However, the root module does not have cluster_names variable. Therefore, https://github.com/cookpad/terraform-aws-eks/pull/204/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR7 always fail.

This PR enables the root module pass `cluster_names` variable to the vpc module correctly.


## Note

We still have bug even if we merge this PR as https://github.com/cookpad/terraform-aws-eks/pull/257 is describing. But let me focus on one issue at a time.