### PR TITLE
Remove cluster-name tagging from subnets

### DIFF
--- a/examples/cluster/environment/main.tf
+++ b/examples/cluster/environment/main.tf
@@ -10,7 +10,6 @@ module "vpc" {
   name               = var.vpc_name
   cidr_block         = var.cidr_block
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1d"]
-  cluster_names      = var.cluster_names
 }
 
 module "iam" {

--- a/examples/cluster/environment/variables.tf
+++ b/examples/cluster/environment/variables.tf
@@ -7,9 +7,3 @@ variable "cidr_block" {
   type    = string
   default = "10.0.0.0/18"
 }
-
-variable "cluster_names" {
-  description = "Names of the EKS clusters deployed in this VPC."
-  type        = list(string)
-  default     = []
-}

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -10,5 +10,4 @@ module "vpc" {
   name               = var.vpc_name
   cidr_block         = var.cidr_block
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  cluster_names      = var.cluster_names
 }

--- a/examples/vpc/variables.tf
+++ b/examples/vpc/variables.tf
@@ -7,9 +7,3 @@ variable "cidr_block" {
   type    = string
   default = "10.0.0.0/18"
 }
-
-variable "cluster_names" {
-  description = "Names of the EKS clusters deployed in this VPC."
-  type        = list(string)
-  default     = []
-}

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,6 @@ module "vpc" {
   name               = var.cluster_name
   cidr_block         = var.cidr_block
   availability_zones = var.availability_zones
-  cluster_names      = var.cluster_names
 }
 
 module "iam" {

--- a/modules/vpc/subnets.tf
+++ b/modules/vpc/subnets.tf
@@ -1,6 +1,5 @@
 locals {
   az_subnet_numbers = zipmap(var.availability_zones, range(0, length(var.availability_zones)))
-  cluster_tags      = { for cluster_name in var.cluster_names : "kubernetes.io/cluster/${cluster_name}" => "shared" }
 }
 
 resource "aws_subnet" "public" {
@@ -11,14 +10,11 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.network.id
   map_public_ip_on_launch = true
 
-  tags = merge(
-    local.cluster_tags,
-    {
-      Name                             = "${var.name}-public-${each.key}"
-      "kubernetes.io/role/elb"         = "1"
-      "kubernetes.io/role/alb-ingress" = "1"
-    }
-  )
+  tags = {
+    Name                             = "${var.name}-public-${each.key}"
+    "kubernetes.io/role/elb"         = "1"
+    "kubernetes.io/role/alb-ingress" = "1"
+  }
 }
 
 resource "aws_route_table_association" "public" {
@@ -36,14 +32,11 @@ resource "aws_subnet" "private" {
   vpc_id                  = aws_vpc.network.id
   map_public_ip_on_launch = false
 
-  tags = merge(
-    local.cluster_tags,
-    {
-      Name                              = "${var.name}-private-${each.key}"
-      "kubernetes.io/role/internal-elb" = "1"
-      "kubernetes.io/role/alb-ingress"  = "1"
-    }
-  )
+  tags = {
+    Name                              = "${var.name}-private-${each.key}"
+    "kubernetes.io/role/internal-elb" = "1"
+    "kubernetes.io/role/alb-ingress"  = "1"
+  }
 }
 
 resource "aws_route_table_association" "private" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -11,9 +11,3 @@ variable "cidr_block" {
 variable "availability_zones" {
   description = "The availability zones to create subnets in"
 }
-
-variable "cluster_names" {
-  description = "Names of the EKS clusters deployed in this VPC."
-  type        = list(string)
-  default     = []
-}

--- a/modules/vpc/vpc.tf
+++ b/modules/vpc/vpc.tf
@@ -1,18 +1,8 @@
 resource "aws_vpc" "network" {
   cidr_block           = var.cidr_block
   enable_dns_hostnames = true
-  tags = merge(
-    local.cluster_tags,
-    {
-      Name = var.name
-    }
-  )
-
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to tags: eks adds the kubernetes.io/cluster/${cluster_name} tag
-      tags,
-    ]
+  tags = {
+    Name = var.name
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@ variable "cluster_name" {
   description = "A name for the EKS cluster, and the resources it depends on"
 }
 
-variable "cluster_names" {
-  type        = list(string)
-  description = ""
-}
-
 variable "cidr_block" {
   type        = string
   description = "The CIDR block for the VPC that EKS will run in"


### PR DESCRIPTION
* These tags were previously required by aws-load-balancer-controller/alb-ingress-controller
* We no longer ship an ingress controller with the module since #225
* aws-load-balancer-controller doesn't need those tags anyway since v2.1.2 - https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1773