### PR TITLE
Throw an error if the node-group label name is too long

### DIFF
--- a/modules/asg_node_group/versions.tf
+++ b/modules/asg_node_group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    assert = {
+      source  = "bwoznicki/assert"
+      version = "0.0.1"
+    }
+  }
+}


### PR DESCRIPTION
kubernetes labels have a 63 character limitation:
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

As node-group label names may be calculated, they could exceed this
length, which results in bottlerocket configuration errors.