### PR TITLE
require aws provider version >= 3.49.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@main
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.24
+          terraform_version: 0.12.31
       - name: 'Terraform Format'
         run: terraform fmt -check -recursive
       - name: 'Terraform Init cluster'

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ to assume a common IAM role in the aws provider definition.
 ```hcl
 provider "aws" {
   region              = "us-east-1"
-  version             = "3.5.0"
+  version             = "3.49.0"
   assume_role {
     role_arn = "arn:aws:iam::<your account id>:role/Terraform"
   }

--- a/examples/cluster/bottlerocket_node_group/main.tf
+++ b/examples/cluster/bottlerocket_node_group/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region              = "us-east-1"
-  version             = "3.5.0"
+  version             = "3.49.0"
   allowed_account_ids = ["214219211678"]
 }
 

--- a/examples/cluster/environment/main.tf
+++ b/examples/cluster/environment/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region              = "us-east-1"
-  version             = "3.5.0"
+  version             = "3.49.0"
   allowed_account_ids = ["214219211678"]
 }
 

--- a/examples/cluster/gpu_node_group/main.tf
+++ b/examples/cluster/gpu_node_group/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region              = "us-east-1"
-  version             = "3.5.0"
+  version             = "3.49.0"
   allowed_account_ids = ["214219211678"]
 }
 

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region              = "us-east-1"
-  version             = "3.5.0"
+  version             = "3.49.0"
   allowed_account_ids = ["214219211678"]
 }
 

--- a/examples/cluster/standard_node_group/main.tf
+++ b/examples/cluster/standard_node_group/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region              = "us-east-1"
-  version             = "3.5.0"
+  version             = "3.49.0"
   allowed_account_ids = ["214219211678"]
 }
 

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region              = "us-east-1"
-  version             = "3.5.0"
+  version             = "3.49.0"
   allowed_account_ids = ["214219211678"]
 }
 

--- a/modules/asg_node_group/providers.tf
+++ b/modules/asg_node_group/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.49"
+    }
+  }
+}

--- a/modules/cluster/providers.tf
+++ b/modules/cluster/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.49"
+    }
+  }
+}

--- a/modules/iam/providers.tf
+++ b/modules/iam/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.49"
+    }
+  }
+}

--- a/modules/vpc/providers.tf
+++ b/modules/vpc/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.49"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.31"
 }


### PR DESCRIPTION
Since #240 we require secret encrytion on all clusters. Users hit this bug after enabling secret encryption hashicorp/terraform-provider-aws#19986 unless using aws provider >=3.49.0

NB: for the 1.20 release this will be superseded by #261, but intending to patch this to 1.19.2 for users using https://github.com/cookpad/terraform-aws-eks/pull/240 in 1.19.1 as they will hit 🐛  hashicorp/terraform-provider-aws#19986