### PR TITLE
Use endpoint_public_access=true for root module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,10 @@ module "cluster" {
   vpc_config = module.vpc.config
   iam_config = module.iam.config
 
-  aws_auth_role_map = var.aws_auth_role_map
-  aws_auth_user_map = var.aws_auth_user_map
+  aws_auth_role_map            = var.aws_auth_role_map
+  aws_auth_user_map            = var.aws_auth_user_map
+  endpoint_public_access       = var.endpoint_public_access
+  endpoint_public_access_cidrs = var.endpoint_public_access_cidrs
 }
 
 module "node_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,14 @@ variable "aws_auth_user_map" {
   default     = []
   description = "A list of mappings from aws user arns to kubernetes users, and their groups"
 }
+
+variable "endpoint_public_access" {
+  type        = bool
+  description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled."
+  default     = true
+}
+
+variable "endpoint_public_access_cidrs" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
The root module is not intended for production use. To make it easy for users to get started, using endpoint_public_access=true allows users to get started without configuring any custom networking to access the EKS api.

Closes #251 

@aidy as discussed - this updates the root module to default to
```
  endpoint_public_access       = true
  endpoint_public_access_cidrs = ["0.0.0.0/0"]
```
in the cluster module. This is against the recommended pattern introduced in #240, but to close #251 we want to provide configuration that works easily for the user. From 1.20 we will remove the root module, so this is intended only for patching 1.19

NB: we don't run any CI steps against the root module, but validating:

```
$ terraform validate                                                                                                                                                                                                                                

Warning: Provider source not supported in Terraform v0.12

  on ../../Documents/code/open-source/terraform-aws-eks/modules/asg_node_group/providers.tf line 3, in terraform:
   3:     aws = {
   4:       source  = "hashicorp/aws"
   5:       version = "~> 3.49"
   6:     }

A source was declared for provider aws. Terraform v0.12 does not support the
provider source attribute. It will be ignored.

(and 4 more similar warnings elsewhere)

Success! The configuration is valid, but there were some validation warnings as shown above.
```