### PR TITLE
Avoid InvalidParameterException

### DIFF
--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -11,7 +11,7 @@ variable "endpoint_public_access" {
 
 variable "endpoint_public_access_cidrs" {
   type    = list(string)
-  default = []
+  default = null
 }
 
 variable "cluster_log_types" {


### PR DESCRIPTION
close https://github.com/cookpad/terraform-aws-eks/issues/288

When endpoint_public_access_cidrs is `[]`, acutual value for
Public Endpoint Restrictions will be `[0.0.0.0/0]`.

But Terraform try to update the "Public Endpoint Restriction"
to [0.0.0.0/0] from secound apply and onward and throws
InvalidParameterException.

It is required to set `null` or explicitly set some value like
`["0.0.0.0/0"]` to void the error.

I think using null is better than `["0.0.0.0/0"]` as it falls to
default of aws_eks_cluster resource.