### PR TITLE
Update kubeconfig to use client.authentication.k8s.io/v1beta1

### DIFF
--- a/modules/cluster/kubectl/kubeconfig.yaml
+++ b/modules/cluster/kubectl/kubeconfig.yaml
@@ -9,7 +9,7 @@ users:
 - name: ${cluster_name}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws
       args:
         - "eks"


### PR DESCRIPTION
Currently, when you try to do `terraform apply` on the machine with `kubectl` version 1.24+, you will run into this error:

```
╷
│ Error: local-exec provisioner error
│ 
│   with module.staging-eks-cluster.module.nvidia_device_plugin.null_resource.apply[0],
│   on .terraform/modules/staging-eks-cluster/modules/cluster/kubectl/main.tf line 37, in resource "null_resource" "apply":
│   37:   provisioner "local-exec" {
│ 
│ Error running command 'echo "$KUBECONFIG" > .terraform/modules/staging-eks-cluster/modules/cluster/kubectl/045cff270a0a0c5ff6c5dc81689cc1b02625724a.kubeconfig
│ 
│ echo "$MANIFEST" | kubectl --kubeconfig=.terraform/modules/staging-eks-cluster/modules/cluster/kubectl/045cff270a0a0c5ff6c5dc81689cc1b02625724a.kubeconfig apply -f - || echo "$MANIFEST" | kubectl
│ --kubeconfig=.terraform/modules/staging-eks-cluster/modules/cluster/kubectl/045cff270a0a0c5ff6c5dc81689cc1b02625724a.kubeconfig replace --force --save-config -f -
│ 
│ 
│ 
│ rm .terraform/modules/staging-eks-cluster/modules/cluster/kubectl/045cff270a0a0c5ff6c5dc81689cc1b02625724a.kubeconfig
│ ': exit status 1. Output: error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
│ error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
│ 
╵
```

This is because k8s version 1.24+ has removed `client.authentication.k8s.io/v1alpha1`.

Related issue on flux: https://github.com/fluxcd/flux2/issues/2817#issuecomment-1149581573

This PR updates `kubeconfig.yaml` to use `client.authentication.k8s.io/v1beta1` instead.