### PR TITLE
Add imdsv2_required flag for critical addons asg

### DIFF
--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -17,6 +17,8 @@ module "critical_addons_node_group" {
   bottlerocket_admin_container_superpowered = var.critical_addons_node_group_bottlerocket_admin_container_superpowered
   bottlerocket_admin_container_source       = var.critical_addons_node_group_bottlerocket_admin_container_source
 
+  imdsv2_required = var.critical_addons_imdsv2_required
+
   zone_awareness = false
   taints = {
     "CriticalAddonsOnly" = "true:NoSchedule"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -195,7 +195,7 @@ variable "security_group_ids" {
   description = "A list of security group IDs for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication with the Kubernetes control plane. *WARNING* changes to this list will cause the cluster to be recreated."
 }
 
-variable "imdsv2_required" {
+variable "critical_addons_imdsv2_required" {
   type        = bool
   default     = true
   description = "Security - whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). If you re using kube2iam make it false"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -194,3 +194,9 @@ variable "security_group_ids" {
   default     = []
   description = "A list of security group IDs for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication with the Kubernetes control plane. *WARNING* changes to this list will cause the cluster to be recreated."
 }
+
+variable "imdsv2_required" {
+  type        = bool
+  default     = true
+  description = "Security - whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). If you re using kube2iam make it false"
+}


### PR DESCRIPTION
The ML team depends on the flag `imdsv2_required` in one of our clusters because we still use `kube2iam` for an app.

We need to be able to pass this flag to the `critical_addons` ASG because `kube2iam` pod can't startup in those nodes. 

This is my first PR into the module. Happy to help with the release process but will need some guidance :)