### PR TITLE
Support migration to self-managed CoreDNS

### DIFF
--- a/docs/self_managed_coredns.md
+++ b/docs/self_managed_coredns.md
@@ -1,0 +1,24 @@
+# Self-managed CoreDNS
+
+This document describes how to migrate from CoreDNS as an EKS addon to self-managed CoreDNS.
+
+> :warning: It is recommended that new clusters use the EKS addon, even if you intend to immediately migrate to self-managed.
+
+## Steps
+
+1. Ensure that the `critical_addons_coredns_preserve` variable is configured to `true`. This is the default value, and ensures no downtime for DNS during the migration.
+1. In a separate plan/apply, set the `critical_addons_coredns_enabled` variable to `false`. This will delete the EKS addon, without deleting the associated manifests in the cluster.
+1. Start managing the CoreDNS manifests however you see fit.
+
+> :memo: It may be useful to take a snapshot of the resources previously managed by the addon - you can do so like so:
+> 
+> ```shell
+> kubectl api-resources --verbs=list -o name | xargs -n 1 kubectl get --ignore-not-found -A -l eks.amazonaws.com/component=coredns -o yaml > coredns.yaml
+> ```
+> 
+> Note that this will output more resources than necessary to manage CoreDNS (e.g. Deployment _and_ ReplicaSets _and_ Pods), as well as status fields, so is useful as a reference but should not be copied directly into e.g. your kustomize.
+
+
+## Why?
+
+The EKS addon for CoreDNS does not support reconfiguration (for example increasing replicas), as most `.spec` fields are managed by EKS, and any custom modifications to the CoreDNS resources will be overwritten by the EKS addon. To enable fine grained control over CoreDNS resources, it is necessary to migrate from the EKS addon to a self-managed CoreDNS, and this will usually need to be a seamless transition.

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -46,10 +46,12 @@ resource "aws_eks_addon" "kube-proxy" {
 }
 
 resource "aws_eks_addon" "coredns" {
+  count             = var.critical_addons_coredns_enabled == true ? 1 : 0
   cluster_name      = local.config.name
   addon_name        = "coredns"
   addon_version     = "v1.8.7-eksbuild.2"
   resolve_conflicts = "OVERWRITE"
+  preserve          = var.critical_addons_coredns_preserve
   depends_on = [
     module.critical_addons_node_group
   ]

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -196,8 +196,8 @@ variable "critical_addons_coredns_preserve" {
 }
 
 variable "critical_addons_coredns_enabled" {
-  type = string
-  default = true
+  type        = string
+  default     = true
   description = "Whether to enable CoreDNS addon. Recommended for cluster creation, but can be disabled to migrate to self-managed CoreDNS."
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -189,6 +189,18 @@ variable "critical_addons_node_group_bottlerocket_admin_container_source" {
   description = "URI of a custom admin container image"
 }
 
+variable "critical_addons_coredns_preserve" {
+  type        = string
+  default     = true
+  description = "Whether to preserve CoreDNS resources when deleting the addon. This can be used to migrate to self-managed CoreDNS."
+}
+
+variable "critical_addons_coredns_enabled" {
+  type = string
+  default = true
+  description = "Whether to enable CoreDNS addon. Recommended for cluster creation, but can be disabled to migrate to self-managed CoreDNS."
+}
+
 variable "security_group_ids" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
This PR aims to enable users of the module to migrate to self-managed CoreDNS (as opposed to using the EKS addon).

The [included docs](https://github.com/cookpad/terraform-aws-eks/blob/js/search-3950/support-migration-to-self-managed-coredns/docs/self_managed_coredns.md#self-managed-coredns) describe the intended process for users, as well as reasons why a user may want to manage CoreDNS themselves.

tl;dr I would like to be able to scale CoreDNS in my cluster, but am not currently able to due to the way the EKS addon will overwrite any modifications I make.