### PR TITLE
Support custom configuration values for addons

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,7 @@
 
 * Check the notes for the Kubernetes version you are upgrading to at https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
 * After upgrading the terraform module, remember to follow the [roll nodes](docs/roll_nodes.md) procedure to roll out upgraded nodes to your cluster.
+* If providing custom `configuration_values` for any EKS addons, check for compatibility with the upgraded EKS addon version, using `aws eks describe-addon-configuration`. You can find the EKS addon versions in [addons.tf](modules/cluster/addons.tf)
 
 ## 1.21 -> 1.22
  * Removed yaml k8s addons: nvidia, aws-node-termination-handler, metrics-server, pod_nanny (PR) only remains cluster-autoscaler, The idea is that terraform doesn't manage anymore k8s components in future releases, just the AWS Addons. So Flux or any GitOps system should manage k8s components.

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -26,7 +26,7 @@ module "cluster" {
 
   critical_addons_node_group_key_name = "development"
 
-  critical_addons_coredns_configuration_values = { replicaCount = 3 }
+  critical_addons_coredns_configuration_values = jsonencode({ replicaCount = 3 })
 
   endpoint_public_access       = true
   endpoint_public_access_cidrs = ["${chomp(data.http.ip.body)}/32"]

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -27,9 +27,9 @@ module "cluster" {
   critical_addons_node_group_key_name = "development"
 
   critical_addons_coredns_configuration_values = jsonencode({ replicaCount = 3 })
-
-  endpoint_public_access       = true
-  endpoint_public_access_cidrs = ["${chomp(data.http.ip.body)}/32"]
+  critical_addons_ebs-csi_configuration_value  = jsonencode({ node = { tolerateAllTaints = true } })
+  endpoint_public_access                       = true
+  endpoint_public_access_cidrs                 = ["${chomp(data.http.ip.body)}/32"]
 
 
   aws_auth_role_map = [

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -27,7 +27,7 @@ module "cluster" {
   critical_addons_node_group_key_name = "development"
 
   critical_addons_coredns_configuration_values = jsonencode({ replicaCount = 3 })
-  critical_addons_ebs-csi_configuration_value  = jsonencode({ node = { tolerateAllTaints = true } })
+  critical_addons_ebs-csi_configuration_values = jsonencode({ node = { tolerateAllTaints = true } })
   endpoint_public_access                       = true
   endpoint_public_access_cidrs                 = ["${chomp(data.http.ip.body)}/32"]
 

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.20.1"
+      version = "4.47.0"
     }
   }
 }

--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -26,6 +26,8 @@ module "cluster" {
 
   critical_addons_node_group_key_name = "development"
 
+  critical_addons_coredns_configuration_values = { replicaCount = 3 }
+
   endpoint_public_access       = true
   endpoint_public_access_cidrs = ["${chomp(data.http.ip.body)}/32"]
 

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -38,7 +38,7 @@ resource "aws_eks_addon" "vpc-cni" {
   addon_name           = "vpc-cni"
   addon_version        = "v1.11.2-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = jsonencode(var.critical_addons_vpc-cni_configuration_values)
+  configuration_values = var.critical_addons_vpc-cni_configuration_values ? jsonencode(var.critical_addons_vpc-cni_configuration_values) : null
 }
 
 resource "aws_eks_addon" "kube-proxy" {
@@ -46,7 +46,7 @@ resource "aws_eks_addon" "kube-proxy" {
   addon_name           = "kube-proxy"
   addon_version        = "v1.23.7-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = jsonencode(var.critical_addons_kube-proxy_configuration_values)
+  configuration_values = var.critical_addons_kube-proxy_configuration_values ? jsonencode(var.critical_addons_kube-proxy_configuration_values) : null
 }
 
 resource "aws_eks_addon" "coredns" {
@@ -54,7 +54,7 @@ resource "aws_eks_addon" "coredns" {
   addon_name           = "coredns"
   addon_version        = "v1.8.7-eksbuild.2"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = jsonencode(var.critical_addons_coredns_configuration_values)
+  configuration_values = var.critical_addons_coredns_configuration_values ? jsonencode(var.critical_addons_coredns_configuration_values) : null
   depends_on = [
     module.critical_addons_node_group
   ]
@@ -67,7 +67,7 @@ resource "aws_eks_addon" "ebs-csi" {
   addon_version            = "v1.10.0-eksbuild.1"
   service_account_role_arn = local.aws_ebs_csi_driver_iam_role_arn
   resolve_conflicts        = "OVERWRITE"
-  configuration_values     = jsonencode(var.critical_addons_ebs-csi_configuration_values)
+  configuration_values     = var.critical_addons_ebs-csi_configuration_values ? jsonencode(var.critical_addons_ebs-csi_configuration_values) : null
   depends_on = [
     module.critical_addons_node_group
   ]

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -30,13 +30,15 @@ module "critical_addons_node_group" {
 data "aws_region" "current" {}
 
 // When upgrading k8s version run `aws eks describe-addon-versions --kubernetes-version <version>` to get addon_version numbers
+// You should then check the configuration values schema, and update the structured type in variables.tf
+// `eks describe-addon-configuration --addon-name <addon-name> --addon-version <addon-version> | jq -r '.configurationSchema' | jq
 
 resource "aws_eks_addon" "vpc-cni" {
   cluster_name         = local.config.name
   addon_name           = "vpc-cni"
   addon_version        = "v1.11.2-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_vpc-cni_configuration_values
+  configuration_values = jsonencode(var.critical_addons_vpc-cni_configuration_values)
 }
 
 resource "aws_eks_addon" "kube-proxy" {
@@ -44,7 +46,7 @@ resource "aws_eks_addon" "kube-proxy" {
   addon_name           = "kube-proxy"
   addon_version        = "v1.23.7-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_kube-proxy_configuration_values
+  configuration_values = jsonencode(var.critical_addons_kube-proxy_configuration_values)
 }
 
 resource "aws_eks_addon" "coredns" {
@@ -52,7 +54,7 @@ resource "aws_eks_addon" "coredns" {
   addon_name           = "coredns"
   addon_version        = "v1.8.7-eksbuild.2"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_coredns_configuration_values
+  configuration_values = jsonencode(var.critical_addons_coredns_configuration_values)
   depends_on = [
     module.critical_addons_node_group
   ]
@@ -65,7 +67,7 @@ resource "aws_eks_addon" "ebs-csi" {
   addon_version            = "v1.10.0-eksbuild.1"
   service_account_role_arn = local.aws_ebs_csi_driver_iam_role_arn
   resolve_conflicts        = "OVERWRITE"
-  configuration_values     = var.critical_addons_ebs-csi_configuration_values
+  configuration_values     = jsonencode(var.critical_addons_ebs-csi_configuration_values)
   depends_on = [
     module.critical_addons_node_group
   ]

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -38,7 +38,7 @@ resource "aws_eks_addon" "vpc-cni" {
   addon_name           = "vpc-cni"
   addon_version        = "v1.11.2-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_vpc-cni_configuration_values ? jsonencode(var.critical_addons_vpc-cni_configuration_values) : null
+  configuration_values = var.critical_addons_vpc-cni_configuration_values != null ? jsonencode(var.critical_addons_vpc-cni_configuration_values) : null
 }
 
 resource "aws_eks_addon" "kube-proxy" {
@@ -46,7 +46,7 @@ resource "aws_eks_addon" "kube-proxy" {
   addon_name           = "kube-proxy"
   addon_version        = "v1.23.7-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_kube-proxy_configuration_values ? jsonencode(var.critical_addons_kube-proxy_configuration_values) : null
+  configuration_values = var.critical_addons_kube-proxy_configuration_values != null ? jsonencode(var.critical_addons_kube-proxy_configuration_values) : null
 }
 
 resource "aws_eks_addon" "coredns" {
@@ -54,7 +54,7 @@ resource "aws_eks_addon" "coredns" {
   addon_name           = "coredns"
   addon_version        = "v1.8.7-eksbuild.2"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_coredns_configuration_values ? jsonencode(var.critical_addons_coredns_configuration_values) : null
+  configuration_values = var.critical_addons_coredns_configuration_values != null ? jsonencode(var.critical_addons_coredns_configuration_values) : null
   depends_on = [
     module.critical_addons_node_group
   ]
@@ -67,7 +67,7 @@ resource "aws_eks_addon" "ebs-csi" {
   addon_version            = "v1.10.0-eksbuild.1"
   service_account_role_arn = local.aws_ebs_csi_driver_iam_role_arn
   resolve_conflicts        = "OVERWRITE"
-  configuration_values     = var.critical_addons_ebs-csi_configuration_values ? jsonencode(var.critical_addons_ebs-csi_configuration_values) : null
+  configuration_values     = var.critical_addons_ebs-csi_configuration_values != null ? jsonencode(var.critical_addons_ebs-csi_configuration_values) : null
   depends_on = [
     module.critical_addons_node_group
   ]

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -32,24 +32,27 @@ data "aws_region" "current" {}
 // When upgrading k8s version run `aws eks describe-addon-versions --kubernetes-version <version>` to get addon_version numbers
 
 resource "aws_eks_addon" "vpc-cni" {
-  cluster_name      = local.config.name
-  addon_name        = "vpc-cni"
-  addon_version     = "v1.11.2-eksbuild.1"
-  resolve_conflicts = "OVERWRITE"
+  cluster_name         = local.config.name
+  addon_name           = "vpc-cni"
+  addon_version        = "v1.11.2-eksbuild.1"
+  resolve_conflicts    = "OVERWRITE"
+  configuration_values = var.critical_addons_vpc-cni_configuration_values
 }
 
 resource "aws_eks_addon" "kube-proxy" {
-  cluster_name      = local.config.name
-  addon_name        = "kube-proxy"
-  addon_version     = "v1.23.7-eksbuild.1"
-  resolve_conflicts = "OVERWRITE"
+  cluster_name         = local.config.name
+  addon_name           = "kube-proxy"
+  addon_version        = "v1.23.7-eksbuild.1"
+  resolve_conflicts    = "OVERWRITE"
+  configuration_values = var.critical_addons_kube-proxy_configuration_values
 }
 
 resource "aws_eks_addon" "coredns" {
-  cluster_name      = local.config.name
-  addon_name        = "coredns"
-  addon_version     = "v1.8.7-eksbuild.2"
-  resolve_conflicts = "OVERWRITE"
+  cluster_name         = local.config.name
+  addon_name           = "coredns"
+  addon_version        = "v1.8.7-eksbuild.2"
+  resolve_conflicts    = "OVERWRITE"
+  configuration_values = var.critical_addons_coredns_configuration_values
   depends_on = [
     module.critical_addons_node_group
   ]
@@ -62,6 +65,7 @@ resource "aws_eks_addon" "ebs-csi" {
   addon_version            = "v1.10.0-eksbuild.1"
   service_account_role_arn = local.aws_ebs_csi_driver_iam_role_arn
   resolve_conflicts        = "OVERWRITE"
+  configuration_values     = var.critical_addons_ebs-csi_configuration_values
   depends_on = [
     module.critical_addons_node_group
   ]

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -29,9 +29,15 @@ module "critical_addons_node_group" {
 
 data "aws_region" "current" {}
 
-// When upgrading k8s version run `aws eks describe-addon-versions --kubernetes-version <version>` to get addon_version numbers
-// You should then check the configuration values schema, and update the structured type in variables.tf
-// `eks describe-addon-configuration --addon-name <addon-name> --addon-version <addon-version> | jq -r '.configurationSchema' | jq
+/* When upgrading k8s version run `aws eks describe-addon-versions --kubernetes-version <version>` to get possible
+addon_version numbers.
+
+If upgrading EKS addon versions, check the configuration values schema using the command below, and make a note of any
+breaking changes in `UPGRADING.md`.
+
+eks describe-addon-configuration --addon-name <addon-name> --addon-version <addon-version> | jq -r '.configurationSchema' | jq
+
+*/
 
 resource "aws_eks_addon" "vpc-cni" {
   cluster_name         = local.config.name

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -38,7 +38,7 @@ resource "aws_eks_addon" "vpc-cni" {
   addon_name           = "vpc-cni"
   addon_version        = "v1.11.2-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_vpc-cni_configuration_values != null ? jsonencode(var.critical_addons_vpc-cni_configuration_values) : null
+  configuration_values = var.critical_addons_vpc-cni_configuration_values
 }
 
 resource "aws_eks_addon" "kube-proxy" {
@@ -46,7 +46,7 @@ resource "aws_eks_addon" "kube-proxy" {
   addon_name           = "kube-proxy"
   addon_version        = "v1.23.7-eksbuild.1"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_kube-proxy_configuration_values != null ? jsonencode(var.critical_addons_kube-proxy_configuration_values) : null
+  configuration_values = var.critical_addons_kube-proxy_configuration_values
 }
 
 resource "aws_eks_addon" "coredns" {
@@ -54,7 +54,7 @@ resource "aws_eks_addon" "coredns" {
   addon_name           = "coredns"
   addon_version        = "v1.8.7-eksbuild.2"
   resolve_conflicts    = "OVERWRITE"
-  configuration_values = var.critical_addons_coredns_configuration_values != null ? jsonencode(var.critical_addons_coredns_configuration_values) : null
+  configuration_values = var.critical_addons_coredns_configuration_values
   depends_on = [
     module.critical_addons_node_group
   ]
@@ -67,7 +67,7 @@ resource "aws_eks_addon" "ebs-csi" {
   addon_version            = "v1.10.0-eksbuild.1"
   service_account_role_arn = local.aws_ebs_csi_driver_iam_role_arn
   resolve_conflicts        = "OVERWRITE"
-  configuration_values     = var.critical_addons_ebs-csi_configuration_values != null ? jsonencode(var.critical_addons_ebs-csi_configuration_values) : null
+  configuration_values     = var.critical_addons_ebs-csi_configuration_values
   depends_on = [
     module.critical_addons_node_group
   ]

--- a/modules/cluster/providers.tf
+++ b/modules/cluster/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.49.0, < 5.0.0"
+      version = ">= 4.47.0, < 5.0.0"
     }
   }
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -190,25 +190,72 @@ variable "critical_addons_node_group_bottlerocket_admin_container_source" {
 }
 
 variable "critical_addons_vpc-cni_configuration_values" {
-  type        = string
+  type = object(
+    {
+      resources = object({ limits = object({ cpu = string, memory = string }), requests = object({ cpu = string, memory = string }) }),
+      env = object(
+        {
+          ADDITIONAL_ENI_TAGS                   = string,
+          ANNOTATE_POD_IP                       = string,
+          AWS_VPC_CNI_NODE_PORT_SUPPORT         = string,
+          AWS_VPC_ENI_MTU                       = string,
+          AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER    = string,
+          AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG    = string,
+          AWS_VPC_K8S_CNI_EXTERNALSNAT          = string,
+          AWS_VPC_K8S_CNI_LOGLEVEL              = string,
+          AWS_VPC_K8S_CNI_LOG_FILE              = string,
+          AWS_VPC_K8S_CNI_RANDOMIZESNAT         = string,
+          AWS_VPC_K8S_CNI_VETHPREFIX            = string,
+          AWS_VPC_K8S_PLUGIN_LOG_FILE           = string,
+          AWS_VPC_K8S_PLUGIN_LOG_LEVEL          = string,
+          DISABLE_INTROSPECTION                 = string,
+          DISABLE_METRICS                       = string,
+          DISABLE_NETWORK_RESOURCE_PROVISIONING = string,
+          ENABLE_POD_ENI                        = string,
+          ENABLE_PREFIX_DELEGATION              = string,
+          WARM_ENI_TARGET                       = string,
+          WARM_PREFIX_TARGET                    = string
+        }
+      )
+    }
+  )
   default     = null
   description = "Configuration values passed to the vpc-cni EKS addon."
 }
 
 variable "critical_addons_kube-proxy_configuration_values" {
-  type        = string
+  type = object(
+    {
+      ipvs      = object({ scheduler = string }),
+      mode      = string, # "iptables" or "ipvs"
+      resources = object({ limits = object({ cpu = string, memory = string }), requests = object({ cpu = string, memory = string }) })
+    }
+  )
   default     = null
   description = "Configuration values passed to the kube-proxy EKS addon."
 }
 
 variable "critical_addons_coredns_configuration_values" {
-  type        = string
+  type = object(
+    {
+      computeType  = string,
+      corefile     = string,
+      nodeSelector = map(string),
+      replicaCount = number,
+      resources    = object({ limits = object({ cpu = string, memory = string }), requests = object({ cpu = string, memory = string }) })
+    }
+  )
   default     = null
   description = "Configuration values passed to the coredns EKS addon."
 }
 
 variable "critical_addons_ebs-csi_configuration_values" {
-  type        = string
+  type = object(
+    {
+      controller = object({ extraVolumeTags = map(string) }),
+      node       = object({ tolerateAllTaints = bool, volumeAttachLimit = number })
+    }
+  )
   default     = null
   description = "Configuration values passed to the ebs-csi EKS addon."
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -190,72 +190,25 @@ variable "critical_addons_node_group_bottlerocket_admin_container_source" {
 }
 
 variable "critical_addons_vpc-cni_configuration_values" {
-  type = object(
-    {
-      resources = object({ limits = object({ cpu = string, memory = string }), requests = object({ cpu = string, memory = string }) }),
-      env = object(
-        {
-          ADDITIONAL_ENI_TAGS                   = string,
-          ANNOTATE_POD_IP                       = string,
-          AWS_VPC_CNI_NODE_PORT_SUPPORT         = string,
-          AWS_VPC_ENI_MTU                       = string,
-          AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER    = string,
-          AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG    = string,
-          AWS_VPC_K8S_CNI_EXTERNALSNAT          = string,
-          AWS_VPC_K8S_CNI_LOGLEVEL              = string,
-          AWS_VPC_K8S_CNI_LOG_FILE              = string,
-          AWS_VPC_K8S_CNI_RANDOMIZESNAT         = string,
-          AWS_VPC_K8S_CNI_VETHPREFIX            = string,
-          AWS_VPC_K8S_PLUGIN_LOG_FILE           = string,
-          AWS_VPC_K8S_PLUGIN_LOG_LEVEL          = string,
-          DISABLE_INTROSPECTION                 = string,
-          DISABLE_METRICS                       = string,
-          DISABLE_NETWORK_RESOURCE_PROVISIONING = string,
-          ENABLE_POD_ENI                        = string,
-          ENABLE_PREFIX_DELEGATION              = string,
-          WARM_ENI_TARGET                       = string,
-          WARM_PREFIX_TARGET                    = string
-        }
-      )
-    }
-  )
+  type        = string
   default     = null
   description = "Configuration values passed to the vpc-cni EKS addon."
 }
 
 variable "critical_addons_kube-proxy_configuration_values" {
-  type = object(
-    {
-      ipvs      = object({ scheduler = string }),
-      mode      = string, # "iptables" or "ipvs"
-      resources = object({ limits = object({ cpu = string, memory = string }), requests = object({ cpu = string, memory = string }) })
-    }
-  )
+  type        = string
   default     = null
   description = "Configuration values passed to the kube-proxy EKS addon."
 }
 
 variable "critical_addons_coredns_configuration_values" {
-  type = object(
-    {
-      computeType  = string,
-      corefile     = string,
-      nodeSelector = map(string),
-      replicaCount = number,
-      resources    = object({ limits = object({ cpu = string, memory = string }), requests = object({ cpu = string, memory = string }) })
-    }
-  )
+  type        = string
   default     = null
   description = "Configuration values passed to the coredns EKS addon."
 }
 
 variable "critical_addons_ebs-csi_configuration_values" {
-  type = object(
-    {
-      controller = object({ extraVolumeTags = map(string) }),
-      node       = object({ tolerateAllTaints = bool, volumeAttachLimit = number })
-    }
-  )
+  type        = string
   default     = null
   description = "Configuration values passed to the ebs-csi EKS addon."
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -189,6 +189,30 @@ variable "critical_addons_node_group_bottlerocket_admin_container_source" {
   description = "URI of a custom admin container image"
 }
 
+variable "critical_addons_vpc-cni_configuration_values" {
+  type        = string
+  default     = null
+  description = "Configuration values passed to the vpc-cni EKS addon."
+}
+
+variable "critical_addons_kube-proxy_configuration_values" {
+  type        = string
+  default     = null
+  description = "Configuration values passed to the kube-proxy EKS addon."
+}
+
+variable "critical_addons_coredns_configuration_values" {
+  type        = string
+  default     = null
+  description = "Configuration values passed to the coredns EKS addon."
+}
+
+variable "critical_addons_ebs-csi_configuration_values" {
+  type        = string
+  default     = null
+  description = "Configuration values passed to the ebs-csi EKS addon."
+}
+
 variable "security_group_ids" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
This PR exposes addon [`configuration_values`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon#configuration_values) in the cluster module's variables.

This will allow users to configure addons (for example, increasing no. of CoreDNS replicas).

This change can also be cherry-picked onto the 1.22 release branch, but we will need to upgrade the `aws-ebs-csi-driver` addon on that branch to `v1.10.0-eksbuild.1` to support configuration values.