### PR TITLE
Enhancements from web-platform

### DIFF
--- a/modules/cluster/aws_ebs_csi_driver_iam.tf
+++ b/modules/cluster/aws_ebs_csi_driver_iam.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "aws_ebs_csi_driver_assume_role_policy" {
 
 resource "aws_iam_role" "aws_ebs_csi_driver" {
   count                = local.aws_ebs_csi_driver_iam_role_count
-  name                 = "EksEBSCSIDriver-${var.name}"
+  name                 = "${var.iam_role_name_prefix}EksEBSCSIDriver-${var.name}"
   assume_role_policy   = data.aws_iam_policy_document.aws_ebs_csi_driver_assume_role_policy.json
   permissions_boundary = var.aws_ebs_csi_driver_iam_permissions_boundary
 }

--- a/modules/cluster/cluster_autoscaler_iam.tf
+++ b/modules/cluster/cluster_autoscaler_iam.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_assume_role_policy" {
 
 resource "aws_iam_role" "cluster_autoscaler" {
   count                = local.cluster_autoscaler_iam_role_count
-  name                 = "EksClusterAutoscaler-${var.name}"
+  name                 = "${var.iam_role_name_prefix}EksClusterAutoscaler-${var.name}"
   assume_role_policy   = data.aws_iam_policy_document.cluster_autoscaler_assume_role_policy.json
   permissions_boundary = var.cluster_autoscaler_iam_permissions_boundary
 }

--- a/modules/cluster/kubectl/command.sh
+++ b/modules/cluster/kubectl/command.sh
@@ -1,5 +1,14 @@
 echo "$KUBECONFIG" > ${kubeconfig_path}
 
+for i in {0..60}
+do if kubectl --kubeconfig=${kubeconfig_path} cluster-info &> /dev/null; then
+  break
+else
+  echo "cluster isn't ready yet"
+  sleep 5
+fi
+done
+
 %{ for r in replace ~}
 echo "$MANIFEST" | kubectl --kubeconfig=${kubeconfig_path} apply -f - || echo "$MANIFEST" | kubectl --kubeconfig=${kubeconfig_path} replace --force --save-config -f -
 %{ endfor ~}

--- a/modules/cluster/kubectl/main.tf
+++ b/modules/cluster/kubectl/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  caller_role_info = regexall("arn:aws:sts::(?P<account>\\d+):assumed-role/(?P<role>\\w+)/\\d+", data.aws_caller_identity.current.arn)
+  caller_role_info = regexall("arn:aws:sts::(?P<account>\\d+):assumed-role/(?P<role>\\w+)/\\S+", data.aws_caller_identity.current.arn)
   caller_role_arn  = length(local.caller_role_info) > 0 ? "arn:aws:iam::${local.caller_role_info[0]["account"]}:role/${local.caller_role_info[0]["role"]}" : ""
   role_arn         = var.role_arn != "" ? var.role_arn : local.caller_role_arn
 }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -35,12 +35,6 @@ resource "aws_eks_cluster" "control_plane" {
   }
 
   depends_on = [aws_cloudwatch_log_group.control_plane]
-
-  provisioner "local-exec" {
-    # wait for api to be avalible for use before continuing
-    command     = "until curl --output /dev/null --insecure --silent ${self.endpoint}/healthz; do sleep 1; done"
-    working_dir = path.module
-  }
 }
 
 resource "aws_iam_openid_connect_provider" "cluster_oidc" {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -44,6 +44,11 @@ variable "iam_config" {
   description = "The IAM roles used by the cluster, If you use the included IAM module you can provide it's config output variable."
 }
 
+variable "iam_role_name_prefix" {
+  default = ""
+  description = "An optional prefix to any IAM Roles created by this module"
+}
+
 variable "cluster_autoscaler_iam_permissions_boundary" {
   type        = string
   default     = ""

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -45,7 +45,7 @@ variable "iam_config" {
 }
 
 variable "iam_role_name_prefix" {
-  default = ""
+  default     = ""
   description = "An optional prefix to any IAM Roles created by this module"
 }
 


### PR DESCRIPTION
📝 These are some enhancements we have been using on the web platform clusters for some time!

It would be great to merge them in so we can use the mainline release!

* Removes the provisioner that "waits" for the cluster to be ready, and instead adding a similar check to the kubectl command fixes a lot of errors that can require a re-run when provisioning a cluster.
* In our environment we need to give all our IAM roles a specific prefix - this change (optionally) allows this to be done!