### PR TITLE
Tags propagation (respect default_tags, node group ASG, critical node group via cluster)

### DIFF
--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -1,3 +1,5 @@
+data "aws_default_tags" "current" {}
+
 locals {
   k8s_version = "1.23"
   preset_instance_families = {
@@ -21,7 +23,7 @@ locals {
   root_device_mappings = reverse(tolist(data.aws_ami.image.block_device_mappings))[0]
   autoscaler_tags      = var.cluster_autoscaler ? { "k8s.io/cluster-autoscaler/enabled" = "true", "k8s.io/cluster-autoscaler/${var.cluster_config.name}" = "owned" } : {}
   bottlerocket_tags    = var.bottlerocket ? { "Name" = "eks-node-${var.cluster_config.name}" } : {}
-  tags                 = merge(var.cluster_config.tags, var.tags, { "kubernetes.io/cluster/${var.cluster_config.name}" = "owned" }, local.autoscaler_tags, local.bottlerocket_tags)
+  tags                 = merge(data.aws_default_tags.current.tags, var.cluster_config.tags, var.tags, { "kubernetes.io/cluster/${var.cluster_config.name}" = "owned" }, local.autoscaler_tags, local.bottlerocket_tags)
   node_group_label     = var.name != "" ? var.name : local.name_prefix
   cloud_config = templatefile(
     "${path.module}/cloud_config.tpl",

--- a/modules/asg_node_group/main.tf
+++ b/modules/asg_node_group/main.tf
@@ -102,6 +102,9 @@ resource "aws_launch_template" "config" {
     http_put_response_hop_limit = 2
   }
 
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestLaunchTemplateData.html
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html
+
   tag_specifications {
     resource_type = "instance"
     tags          = local.tags
@@ -110,6 +113,20 @@ resource "aws_launch_template" "config" {
   tag_specifications {
     resource_type = "volume"
     tags          = local.tags
+  }
+
+  tag_specifications {
+    resource_type = "network-interface"
+    tags          = local.tags
+  }
+
+  # Unnecessary tag_specification results into launch error (e.g. for resources which will not be created by a launch template)
+  dynamic "tag_specifications" {
+    for_each = var.instance_lifecycle == "spot" ? toset(["spot-instances-request"]) : toset([])
+    content {
+      resource_type = tag_specifications.value
+      tags          = local.tags
+    }
   }
 
   tags = local.tags

--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -17,6 +17,8 @@ module "critical_addons_node_group" {
   bottlerocket_admin_container_superpowered = var.critical_addons_node_group_bottlerocket_admin_container_superpowered
   bottlerocket_admin_container_source       = var.critical_addons_node_group_bottlerocket_admin_container_source
 
+  tags = var.tags
+
   zone_awareness = false
   taints = {
     "CriticalAddonsOnly" = "true:NoSchedule"


### PR DESCRIPTION
This PR improves resource tagging for cost allocation by:

- respect AWS provider's default_tags. ASG needs special handling using `aws_default_tags` data provider.
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags
- Inherit tags to all possible resources defined through launch templates
  - https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestLaunchTemplateData.html
  - https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html
- critical_addons_node_group does not respect `var.tags` specified for cluster module itself