### PR TITLE
Add a poka-yoke to prevent unintentional destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,10 @@ resource "aws_eks_cluster" "control_plane" {
   }
 
   depends_on = [aws_cloudwatch_log_group.control_plane]
+
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -120,3 +120,9 @@ variable "ebs_csi_configuration_values" {
   default     = null
   description = "Configuration values passed to the ebs-csi EKS addon."
 }
+
+variable "prevent_destroy" {
+  type = boolean
+  default = true
+  description = "Prevent the cluster from being destroyed by terraform, useful because some config changes can cause the cluster to be destroyed and recreated"
+}


### PR DESCRIPTION
It's quite easy to make a config change that requires the cluster to be destroyed and recreated.  This is usually not what you want since the state of the cluster will be lost.

This config will prevent terraform from trying to apply a change that requires the cluster to be destroyed ... if that is really what you wanted to do you must set `prevent_destroy = false` first