### PR TITLE
Allow additional_node_role_arns to be specified on karpenter

### DIFF
--- a/modules/karpenter/controller_iam.tf
+++ b/modules/karpenter/controller_iam.tf
@@ -244,7 +244,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
   statement {
     sid       = "AllowPassingInstanceRole"
     effect    = "Allow"
-    resources = [aws_iam_role.karpenter_node.arn]
+    resources = concat([aws_iam_role.karpenter_node.arn], var.additional_node_role_arns)
     actions   = ["iam:PassRole"]
 
     condition {

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -16,3 +16,15 @@ variable "oidc_config" {
     arn = string
   })
 }
+
+variable "additional_node_role_arns" {
+  description = <<-EOF
+    Additional Node Role ARNS that karpenter should manage
+
+    This can be used where karpenter is using existing node
+    roles, and you want to transition to the namespaced role
+    created by this module
+  EOF
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
This may be needed for migration, if for example karpenter is already managing nodes with a different node role arn, so that it can continue to manage existing nodes until they are replaced.