### PR TITLE
Use inline policy for v1beta to avoid resource recreation

### DIFF
--- a/modules/karpenter/controller_iam.tf
+++ b/modules/karpenter/controller_iam.tf
@@ -28,16 +28,16 @@ data "aws_iam_policy_document" "karpenter_controller_assume_role_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "karpenter_controller_v1_beta" {
-  count      = var.v1beta ? 1 : 0
-  role       = aws_iam_role.karpenter_controller.id
-  policy_arn = aws_iam_policy.karpenter_controller_v1_beta[0].arn
+resource "aws_iam_role_policy" "karpenter_controller_v1_beta" {
+  count  = var.v1beta ? 1 : 0
+  name   = "KarpenterController-v1beta"
+  role   = aws_iam_role.karpenter_controller.id
+  policy = data.aws_iam_policy_document.karpenter_controller_v1_beta.json
 }
 
-resource "aws_iam_policy" "karpenter_controller_v1_beta" {
-  count  = var.v1beta ? 1 : 0
-  name   = "${var.cluster_config.iam_policy_name_prefix}KarpenterController-v1beta-${var.cluster_config.name}"
-  policy = data.aws_iam_policy_document.karpenter_controller_v1_beta.json
+moved {
+  from = aws_iam_role_policy.karpenter_controller_v1_beta
+  to   = aws_iam_role_policy.karpenter_controller_v1_beta[0]
 }
 
 data "aws_iam_policy_document" "karpenter_controller_v1_beta" {


### PR DESCRIPTION
follow-up of #371 

In #371, I separated Karpenter v1beta and v1 policies to their own managed policies. However I noticed that when we apply this change, the destruction of `aws_iam_role_policy` and creation of `aws_iam_role_attachment` can happen in any order, possibly result in a moment that no policy is attached to the role... it's sufficient to make only v1 a managed policy to address the original issue, so I revert the v1beta policy back to an inline policy in this PR to prevent the kind of disruption mentioned above.