### PR TITLE
Specify @cookpad/platform-task-force as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cookpad/web-platform-team
+* @cookpad/platform-task-force


### PR DESCRIPTION
Currently this repository specifies @cookpad/web-platform-team as a code owner. The team is merged into @cookpad/platform-task-force, so the code owner should be @cookpad/platform-task-force.