### PR TITLE
Update addon versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,9 +3,9 @@
 locals {
   versions = {
     k8s                = "1.32"
-    vpc_cni            = "v1.19.3-eksbuild.1"
-    kube_proxy         = "v1.32.0-eksbuild.2"
-    coredns            = "v1.11.4-eksbuild.2"
-    aws_ebs_csi_driver = "v1.41.0-eksbuild.1"
+    vpc_cni            = "v1.20.5-eksbuild.1"
+    kube_proxy         = "v1.32.11-eksbuild.5"
+    coredns            = "v1.11.4-eksbuild.28"
+    aws_ebs_csi_driver = "v1.56.0-eksbuild.1"
   }
 }


### PR DESCRIPTION
Updates
 * vpc-cni from 1.19.3 to 1.20.5
 * kube-proxy from 1.32.0 to 1.32.11
 * aws-ebs-csi-driver from 1.41.0 to 1.56.0
 
 To support intermediate upgrade before upgrading to k8s 1.33
 
 📝 Documentation states that the vpc-cni should only be upgraded by 1 minor version at a time - so whilst the highest supported version of this addon for k8s 1.32 is 1.21.1 I have pinned this to 1.20.5 to avoid any issues.