### PR TITLE
Update addon versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,9 +3,9 @@
 locals {
   versions = {
     k8s                = "1.33"
-    vpc_cni            = "v1.20.4-eksbuild.3"
-    kube_proxy         = "v1.33.5-eksbuild.2"
-    coredns            = "v1.12.4-eksbuild.1"
-    aws_ebs_csi_driver = "v1.53.0-eksbuild.1"
+    vpc_cni            = "v1.21.1-eksbuild.3"
+    kube_proxy         = "v1.33.8-eksbuild.4"
+    coredns            = "v1.13.2-eksbuild.1"
+    aws_ebs_csi_driver = "v1.56.0-eksbuild.1"
   }
 }


### PR DESCRIPTION
Updates

vpc-cni from 1.20.4 to 1.21.1
kube-proxy from 1.33.5 to 1.33.8
coredns from 1.12.4 to 1.13.2
aws-ebs-csi-driver from 1.53.0 to 1.56.0

To support intermediate upgrade before upgrading to k8s 1.34